### PR TITLE
Cleanup and Unit Test Repairs

### DIFF
--- a/src/Prism.Avalonia/Common/MvvmHelpers.cs
+++ b/src/Prism.Avalonia/Common/MvvmHelpers.cs
@@ -9,6 +9,15 @@ namespace Prism.Common
     /// </summary>
     public static class MvvmHelpers
     {
+        /// <summary>
+        /// Sets the AutoWireViewModel property to true for the <paramref name="viewOrViewModel"/>.
+        /// </summary>
+        /// <remarks>
+        /// The AutoWireViewModel property will only be set to true if the view
+        /// is a <see cref="FrameworkElement"/>, the DataContext of the view is null, and
+        /// the AutoWireViewModel property of the view is null.
+        /// </remarks>
+        /// <param name="viewOrViewModel">The View or ViewModel.</param>
         internal static void AutowireViewModel(object viewOrViewModel)
         {
             if (viewOrViewModel is Control view &&

--- a/src/Prism.Avalonia/Mvvm/ViewModelLocator.cs
+++ b/src/Prism.Avalonia/Mvvm/ViewModelLocator.cs
@@ -21,10 +21,10 @@ namespace Prism.Mvvm
         /// The AutoWireViewModel attached property.
         /// </summary>
         public static AvaloniaProperty AutoWireViewModelProperty =
-            AvaloniaProperty.RegisterAttached<Control, bool>(
+            AvaloniaProperty.RegisterAttached<Control, bool?>(
                 name: "AutoWireViewModel",
                 ownerType: typeof(ViewModelLocator),
-                defaultValue: false);
+                defaultValue: null);
 
         /// <summary>
         /// Gets the value for the <see cref="AutoWireViewModelProperty"/> attached property.

--- a/src/Prism.Avalonia/PrismApplicationBase.cs
+++ b/src/Prism.Avalonia/PrismApplicationBase.cs
@@ -39,6 +39,11 @@ namespace Prism
         /// <summary>
         /// Runs the initialization sequence to configure the Prism application.
         /// </summary>
+        /// <remarks>
+        ///   Though, Prism.WPF v8.1 uses, `protected virtual void Initialize()`
+        ///   Avalonia's AppBuilderBase.cs calls, `.Setup() { ... Instance.Initialize(); ... }`
+        ///   Therefore, we need this as a `public override void` in PrismApplicationBase.cs
+        /// </remarks>
         public override void Initialize()
         {
             base.Initialize();

--- a/src/Prism.Avalonia/Regions/RegionAdapterMappings.cs
+++ b/src/Prism.Avalonia/Regions/RegionAdapterMappings.cs
@@ -75,8 +75,10 @@ namespace Prism.Regions
                 {
                     return mappings[currentType];
                 }
+
                 currentType = currentType.BaseType;
             }
+
             throw new KeyNotFoundException(string.Format(CultureInfo.CurrentCulture, Resources.NoRegionAdapterException, controlType));
         }
 

--- a/src/Prism.Avalonia/Regions/RegionContext.cs
+++ b/src/Prism.Avalonia/Regions/RegionContext.cs
@@ -15,8 +15,6 @@ namespace Prism.Regions
         private static readonly AvaloniaProperty ObservableRegionContextProperty =
             AvaloniaProperty.RegisterAttached<Visual, ObservableObject<object>>("ObservableRegionContext", typeof(RegionContext));
 
-        // Notes: Removed 2022-11-26. This should not be needed according to Avalonia documentaiton.
-        //  https://docs.avaloniaui.net/docs/authoring-controls/defining-properties
         static RegionContext()
         {
             ObservableRegionContextProperty.Changed.Subscribe(args => GetObservableContext(args?.Sender as Visual));

--- a/src/Prism.Avalonia/Regions/RegionContext.cs
+++ b/src/Prism.Avalonia/Regions/RegionContext.cs
@@ -15,6 +15,8 @@ namespace Prism.Regions
         private static readonly AvaloniaProperty ObservableRegionContextProperty =
             AvaloniaProperty.RegisterAttached<Visual, ObservableObject<object>>("ObservableRegionContext", typeof(RegionContext));
 
+        // Notes: Removed 2022-11-26. This should not be needed according to Avalonia documentaiton.
+        //  https://docs.avaloniaui.net/docs/authoring-controls/defining-properties
         static RegionContext()
         {
             ObservableRegionContextProperty.Changed.Subscribe(args => GetObservableContext(args?.Sender as Visual));

--- a/src/Prism.Avalonia/Regions/RegionManager.cs
+++ b/src/Prism.Avalonia/Regions/RegionManager.cs
@@ -164,9 +164,9 @@ namespace Prism.Regions
 
         private static void OnRegionContextChanged(IAvaloniaObject depObj, AvaloniaPropertyChangedEventArgs e)
         {
-            if (RegionContext.GetObservableContext(depObj as Visual).Value != e.NewValue)
+            if (RegionContext.GetObservableContext(depObj as AvaloniaObject).Value != e.NewValue)
             {
-                RegionContext.GetObservableContext(depObj as Visual).Value = e.NewValue;
+                RegionContext.GetObservableContext(depObj as AvaloniaObject).Value = e.NewValue;
             }
         }
 

--- a/tests/Avalonia/Prism.Avalonia.Tests/PrismApplicationBaseFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/PrismApplicationBaseFixture.cs
@@ -19,9 +19,7 @@ namespace Prism.Avalonia.Tests
     /// <summary>Application Base Fixture</summary>
     /// <remarks>
     ///   TODO:
-    ///     - Application.CallOnStartup();
     ///     - Application.Shutdown();
-    ///     - Implement, public void CallOnStartup()
     /// </remarks>
     public class PrismApplicationSetup : IDisposable
     {
@@ -31,7 +29,7 @@ namespace Prism.Avalonia.Tests
         {
             ContainerLocator.ResetContainer();
             Application = new PrismApplication();
-            Application.CallOnStartup();
+            Application.Initialize();
         }
 
         public void Dispose()
@@ -244,11 +242,6 @@ namespace Prism.Avalonia.Tests
         public bool CreateModuleCatalogCalled { get; internal set; }
         public bool CreateContainerExtensionCalled { get; internal set; }
         public bool InitializeCalled { get; internal set; }
-
-        public void CallOnStartup()
-        {
-            // WPF: base.OnStartup(null);
-        }
 
         public override void Initialize()
         {

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionActiveAwareBehaviorFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionActiveAwareBehaviorFixture.cs
@@ -1,3 +1,5 @@
+using Avalonia.Controls;
+using Avalonia.Input;
 using Moq;
 using Prism.Avalonia.Tests.Mocks;
 using Prism.Regions;
@@ -38,7 +40,7 @@ namespace Prism.Avalonia.Tests.Regions.Behaviors
 
             ActiveAwareFrameworkElement activeAwareObject = new ActiveAwareFrameworkElement();
 
-            var frameworkElementMock = new Mock<FrameworkElement>();
+            var frameworkElementMock = new Mock<Control>();
             var frameworkElement = frameworkElementMock.Object;
             frameworkElement.DataContext = activeAwareObject;
 
@@ -63,7 +65,7 @@ namespace Prism.Avalonia.Tests.Regions.Behaviors
             activeAwareMock.SetupProperty(o => o.IsActive);
             var activeAwareObject = activeAwareMock.Object;
 
-            var frameworkElementMock = new Mock<FrameworkElement>();
+            var frameworkElementMock = new Mock<Control>();
             frameworkElementMock.As<IActiveAware>().SetupProperty(o => o.IsActive);
             var frameworkElement = frameworkElementMock.Object;
             frameworkElement.DataContext = activeAwareObject;
@@ -114,7 +116,7 @@ namespace Prism.Avalonia.Tests.Regions.Behaviors
             behavior.Attach();
             var collection = region.MockActiveViews.Items;
 
-            var frameworkElementMock = new Mock<FrameworkElement>();
+            var frameworkElementMock = new Mock<Control>();
             var frameworkElement = frameworkElementMock.Object;
             frameworkElement.DataContext = new object();
 
@@ -306,7 +308,7 @@ namespace Prism.Avalonia.Tests.Regions.Behaviors
             public event EventHandler IsActiveChanged;
         }
 
-        class ActiveAwareFrameworkElement : FrameworkElement, IActiveAware
+        class ActiveAwareFrameworkElement : Control, IActiveAware
         {
             public bool IsActive { get; set; }
             public event EventHandler IsActiveChanged;

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionManagerRegistrationBehaviorFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionManagerRegistrationBehaviorFixture.cs
@@ -7,6 +7,15 @@ using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions.Behaviors
 {
+    /// <summary>
+    /// Region Manager Registration Behavior Fixture tests.
+    /// </summary>
+    /// <remarks>
+    ///   The MockFrameworkElement depends on the following:
+    ///   Avalonia.Control's LoadedEvent and UnloadedEvent wont arrive until Avalonia v0.11.0.
+    ///   Discussion: https://github.com/AvaloniaUI/Avalonia/issues/7908
+    ///   PR: https://github.com/AvaloniaUI/Avalonia/pull/8277
+    /// </remarks>
     public class RegionManagerRegistrationBehaviorFixture
     {
         [StaFact]

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/LocatorNavigationTargetHandlerFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/LocatorNavigationTargetHandlerFixture.cs
@@ -6,8 +6,6 @@ using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions
 {
-    public class FrameworkElement : Control { }
-
     public class LocatorNavigationTargetHandlerFixture
     {
         [Fact]
@@ -124,7 +122,7 @@ namespace Prism.Avalonia.Tests.Regions
                 .Setup(v => v.IsNavigationTarget(It.IsAny<NavigationContext>()))
                 .Returns(true)
                 .Verifiable();
-            var viewMock = new Mock<FrameworkElement>();
+            var viewMock = new Mock<Control>();
             viewMock.Object.DataContext = dataContextMock.Object;
 
             region.Add(viewMock.Object);
@@ -212,7 +210,7 @@ namespace Prism.Avalonia.Tests.Regions
                 .Returns(false)
                 .Verifiable();
 
-            var viewMock = new Mock<FrameworkElement>();
+            var viewMock = new Mock<Control>();
             viewMock.Object.DataContext = dataContextMock.Object;
 
             region.Add(viewMock.Object);

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/RegionNavigationServiceFixture.new.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/RegionNavigationServiceFixture.new.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using Avalonia.Controls;
 using Moq;
 using Prism.Ioc;
 using Prism.Regions;
@@ -189,7 +190,7 @@ namespace Prism.Avalonia.Tests.Regions
             // Prepare
             var region = new Region();
 
-            Mock<FrameworkElement> mockFrameworkElement = new Mock<FrameworkElement>();
+            Mock<Control> mockFrameworkElement = new Mock<Control>();
             Mock<INavigationAware> mockINavigationAwareDataContext = new Mock<INavigationAware>();
             mockINavigationAwareDataContext.Setup(ina => ina.IsNavigationTarget(It.IsAny<NavigationContext>())).Returns(true);
             mockFrameworkElement.Object.DataContext = mockINavigationAwareDataContext.Object;
@@ -224,7 +225,7 @@ namespace Prism.Avalonia.Tests.Regions
             // Prepare
             var region = new Region();
 
-            Mock<FrameworkElement> mockFrameworkElement = new Mock<FrameworkElement>();
+            Mock<Control> mockFrameworkElement = new Mock<Control>();
             Mock<INavigationAware> mockINavigationAwareView = mockFrameworkElement.As<INavigationAware>();
             mockINavigationAwareView.Setup(ina => ina.IsNavigationTarget(It.IsAny<NavigationContext>())).Returns(true);
 
@@ -496,7 +497,7 @@ namespace Prism.Avalonia.Tests.Regions
                 .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<NavigationContext>(), It.IsAny<Action<bool>>()))
                 .Verifiable();
 
-            var viewMock = new Mock<FrameworkElement>();
+            var viewMock = new Mock<Control>();
 
             var view = viewMock.Object;
             view.DataContext = viewModelMock.Object;
@@ -537,7 +538,7 @@ namespace Prism.Avalonia.Tests.Regions
                 .Callback<NavigationContext, Action<bool>>((nc, c) => c(true))
                 .Verifiable();
 
-            var view1Mock = new Mock<FrameworkElement>();
+            var view1Mock = new Mock<Control>();
             var view1 = view1Mock.Object;
             view1.DataContext = view1DataContextMock.Object;
 
@@ -584,7 +585,7 @@ namespace Prism.Avalonia.Tests.Regions
                 .Callback<NavigationContext, Action<bool>>((nc, c) => c(false))
                 .Verifiable();
 
-            var view1Mock = new Mock<FrameworkElement>();
+            var view1Mock = new Mock<Control>();
             var view1 = view1Mock.Object;
             view1.DataContext = view1DataContextMock.Object;
 
@@ -678,7 +679,7 @@ namespace Prism.Avalonia.Tests.Regions
 
             var viewModelMock = new Mock<IConfirmNavigationRequest>();
 
-            var viewMock = new Mock<FrameworkElement>();
+            var viewMock = new Mock<Control>();
             var view = viewMock.Object;
             view.DataContext = viewModelMock.Object;
 
@@ -935,7 +936,7 @@ namespace Prism.Avalonia.Tests.Regions
 
             var mockDataContext = new Mock<INavigationAware>();
 
-            var view1Mock = new Mock<FrameworkElement>();
+            var view1Mock = new Mock<Control>();
             var view1 = view1Mock.Object;
             view1.DataContext = mockDataContext.Object;
 
@@ -1138,7 +1139,7 @@ namespace Prism.Avalonia.Tests.Regions
                 .Callback<NavigationContext, Action<bool>>((nc, c) => c(false))
                 .Verifiable();
 
-            var view1Mock = new Mock<FrameworkElement>();
+            var view1Mock = new Mock<Control>();
             var view1 = view1Mock.Object;
             view1.DataContext = viewModel1Mock.Object;
 

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/RegionViewRegistryFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/RegionViewRegistryFixture.cs
@@ -1,3 +1,4 @@
+using Avalonia.Controls;
 using Moq;
 using Prism.Avalonia.Tests.Mvvm;
 using Prism.Ioc;
@@ -121,11 +122,12 @@ namespace Prism.Avalonia.Tests.Regions
 
             registry.RegisterViewWithRegion("MyRegion", typeof(Mocks.Views.Mock));
 
+            // TODO: AutowireViewModel is not kicking off.
             var result = registry.GetContents("MyRegion");
             Assert.NotNull(result);
             Assert.Single(result);
 
-            var view = result.ElementAt(0) as FrameworkElement;
+            var view = result.ElementAt(0) as Control;
             Assert.IsType<Mocks.Views.Mock>(view);
             Assert.NotNull(view.DataContext);
             Assert.IsType<Mocks.ViewModels.MockViewModel>(view.DataContext);
@@ -147,7 +149,7 @@ namespace Prism.Avalonia.Tests.Regions
             Assert.NotNull(result);
             Assert.Single(result);
 
-            var view = result.ElementAt(0) as FrameworkElement;
+            var view = result.ElementAt(0) as Control;
             Assert.IsType<Mocks.Views.MockOptOut>(view);
             Assert.Null(view.DataContext);
         }


### PR DESCRIPTION
This branch initially set out to address some Unit Tests, and in the process ended up fixing `AutoWireViewModel` to be enabled by default as per the Prism Library design.

This PR is in preparation for Avalonia v0.11-pre migration.

## Feature Includes:
* Fixed AutoWireViewModel defaulting to True (`ViewModelLocator.cs`)
* Fixed Unit Tests (_resolving ~40 tests_)
  * `PrismApplicationBaseFixture` previously not calling `Initialize()`
  * Removed `FrameworkElement` (WPF) shim which wrapped `Avalonia.Controls.Control` object.
* Updated RegionManager to typecast as, `AvaloniaObject` instead of the lower `Visual` object. _Not a bug, just a consistency update`
* Added XML documentation