### PR TITLE
Update DryIoc to v4.8.0 to match Prism Library v8.1.97

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 [Prism.Avalonia](https://github.com/AvaloniaCommunity/Prism.Avalonia) provides your Avalonia apps with [Prism framework](https://github.com/PrismLibrary/Prism) support so you can navigate and perform dependency injection easier than before.
 
-[![Prism.Avalonia NuGet Badge](https://buildstats.info/nuget/Prism.Avalonia?dWidth=70&includePreReleases=true)](https://www.nuget.org/packages/Prism.Avalonia/)
+| Package | NuGet |
+|-|-|
+| Prism.Avalonia | [![Prism.Avalonia NuGet Badge](https://buildstats.info/nuget/Prism.Avalonia?dWidth=70&includePreReleases=true)](https://www.nuget.org/packages/Prism.Avalonia/)
+| Prism.DryIoc.Avalonia | [![Prism.DryIoc.Avalonia NuGet Badge](https://buildstats.info/nuget/Prism.DryIoc.Avalonia?dWidth=70&includePreReleases=true)](https://www.nuget.org/packages/Prism.DryIoc.Avalonia/)
 
 Prism.Avalonia's logic and development approach is similar to that of [Prism for WPF](https://github.com/PrismLibrary/Prism/) so you can get started right away with Prism for Avalonia!
 

--- a/src/Prism.DryIoc.Avalonia/Prism.DryIoc.Avalonia.csproj
+++ b/src/Prism.DryIoc.Avalonia/Prism.DryIoc.Avalonia.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="4.7.7" />
+    <PackageReference Include="DryIoc.dll" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update DryIoc from v4.7.7 to v4.8.0 to match Prism Library v8.1.97

### DryIoc Updates

* Added: [#406](https://github.com/dadhi/DryIoc/issues/406) Allow the registration of the partially closed implementation type
* Fixed: [#405](https://github.com/dadhi/DryIoc/issues/405) DryIoc has waited for the creation of the scoped ... with service name/type