### PR TITLE
Update Window Notification Sample

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,14 +4,16 @@ Change log history for Prism.Avalonia
 
 ## v8.1.97.3-preview.11.5 (2022-02-??)
 
-* Added support for Avalonia v11.0 Preview 5
-* IDialogWindow implements `WindowClosingEventArgs`. See, [Issue #9524](https://github.com/AvaloniaUI/Avalonia/issues/9524), [PR #9715](https://github.com/AvaloniaUI/Avalonia/pull/9715)
-* Avalonia interface objects deprecated - [PR #9553](https://github.com/AvaloniaUI/Avalonia/pull/9553)
+* New: Support for Avalonia v11.0 Preview 5
+* New: Document [Upgrading-to-Avalonia-11.md]
+* Update: IDialogWindow implements `WindowClosingEventArgs`. See, [Issue #9524](https://github.com/AvaloniaUI/Avalonia/issues/9524), [PR #9715](https://github.com/AvaloniaUI/Avalonia/pull/9715)
+* Update: Avalonia interface objects deprecated - [PR #9553](https://github.com/AvaloniaUI/Avalonia/pull/9553)
+* Removed: Reduced the package references
 * Samples:
-  * Upgraded sample projects to support latest Avalonia version
-  * SampleDialogApp - Added MessageBox example
-  * Theme imp
-
+  * ALL: Renamed `.xaml` files to `.axaml` to comply with Avalonia's [XAML Name Reference Generator](https://github.com/AvaloniaUI/Avalonia.NameGenerator)
+  * SampleMvvmApp - `WindowNotificationManager` implementation
+  * SampleDialogApp - Added MessageBox-like dialog example with "title" and "message"
+  * SampleDialogApp - Using Simple Theme instead of Fluent
 
 ## v8.1.97.3-preview.11.4 (2022-02-03)
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,31 @@
 
 [Prism.Avalonia](https://github.com/AvaloniaCommunity/Prism.Avalonia) provides your [Avalonia](https://avaloniaui.net/) apps with [Prism framework](https://github.com/PrismLibrary/Prism) support so you can navigate and perform dependency injection easier than before.  You will need both packages installed to get started.
 
+With Prism.Avalonia's logic and development approach being **similar** to that of [Prism for WPF](https://github.com/PrismLibrary/Prism/), you can get started right away! Keep in mind, they are **similar** and not 1-to-1.
+
 | Package | Stable | Preview
 |-|-|-|
 | Prism.Avalonia | [![Prism.Avalonia NuGet Badge](https://buildstats.info/nuget/Prism.Avalonia?dWidth=70&includePreReleases=false)](https://www.nuget.org/packages/Prism.Avalonia/) | [![Prism.Avalonia NuGet Badge](https://buildstats.info/nuget/Prism.Avalonia?dWidth=70&includePreReleases=true)](https://www.nuget.org/packages/Prism.Avalonia/)
 | Prism.DryIoc.Avalonia | [![Prism.DryIoc.Avalonia NuGet Badge](https://buildstats.info/nuget/Prism.DryIoc.Avalonia?dWidth=70&includePreReleases=false)](https://www.nuget.org/packages/Prism.DryIoc.Avalonia/) | [![Prism.DryIoc.Avalonia NuGet Badge](https://buildstats.info/nuget/Prism.DryIoc.Avalonia?dWidth=70&includePreReleases=true)](https://www.nuget.org/packages/Prism.DryIoc.Avalonia/)
 
+## Version Notice
 
-Prism.Avalonia's logic and development approach is **similar** to that of [Prism for WPF](https://github.com/PrismLibrary/Prism/) so you can get started right away with Prism for Avalonia! Keep in mind, they are **similar** and not 1-to-1.
+Choose the NuGet package version that matches your Avalonia version.
 
-## Changes
+| Avalonia Version | NuGet Package |
+|-|-|
+| 0.10.x          | 8.1.97.2
+| 11.0 Preview 4  | 8.1.97.3-preview.11.4
+| 11.0 Preview 5  | 8.1.97.4-preview.11.5
 
 Be sure to check out the [ChangeLog.md] and [Upgrading-to-Avalonia-11.md] when upgrading your NuGet packages
 
 ## Install
 
-Add the DryIoc package to your project:
+Add the Prism.Avalonia and its DryIoc packages to your project:
 
 ```powershell
+Install-Package Prism.Avalonia -Version 8.1.97.2
 Install-Package Prism.DryIoc.Avalonia -Version 8.1.97.2
 ```
 
@@ -87,6 +95,8 @@ public class App : PrismApplication
 
 ### Program.cs
 
+Your default Avalonia `Program.cs` file does not need modified. Below is provided as a sample.
+
 ```csharp
 public static class Program
 {
@@ -98,11 +108,7 @@ public static class Program
                 EnableMultiTouch = true,
                 UseDBusMenu = true
             })
-            .With(new Win32PlatformOptions
-            {
-                EnableMultitouch = true,
-                AllowEglInitialization = true
-            })
+            .With(new Win32PlatformOptions { AllowEglInitialization = true })
             .UseSkia()
             .UseReactiveUI()
             .UseManagedSystemDialogs();
@@ -146,3 +152,17 @@ public static class Program
     }
 }
 ```
+
+## Branching Strategy
+
+Below is a basic branching hierarchy and strategy.
+
+| Branch | Purpose
+|-|-|
+| `master`    | All releases are tagged published using the `master` branch
+| `develop`   | The **default** & active development branch. When a feature set is completed and ready for public release, the `develop` branch will be merged into `master` and a new NuGet package will be published.
+| `feature/*` | New feature branch. Once completed, it is merged into `develop` and the branch must be deleted.
+
+## Contributing
+
+Prism.Avalonia is an open-source project under the MIT license. We encourage community members like yourself to contribute.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prism.Avalonia
 
-[Prism.Avalonia](https://github.com/AvaloniaCommunity/Prism.Avalonia) provides your [Avalonia](https://avaloniaui.net/) apps with [Prism framework](https://github.com/PrismLibrary/Prism) support so you can navigate and perform dependency injection easier than before.
+[Prism.Avalonia](https://github.com/AvaloniaCommunity/Prism.Avalonia) provides your [Avalonia](https://avaloniaui.net/) apps with [Prism framework](https://github.com/PrismLibrary/Prism) support so you can navigate and perform dependency injection easier than before.  You will need both packages installed to get started.
 
 | Package | Stable | Preview
 |-|-|-|
@@ -8,8 +8,7 @@
 | Prism.DryIoc.Avalonia | [![Prism.DryIoc.Avalonia NuGet Badge](https://buildstats.info/nuget/Prism.DryIoc.Avalonia?dWidth=70&includePreReleases=false)](https://www.nuget.org/packages/Prism.DryIoc.Avalonia/) | [![Prism.DryIoc.Avalonia NuGet Badge](https://buildstats.info/nuget/Prism.DryIoc.Avalonia?dWidth=70&includePreReleases=true)](https://www.nuget.org/packages/Prism.DryIoc.Avalonia/)
 
 
-
-Prism.Avalonia's logic and development approach is similar to that of [Prism for WPF](https://github.com/PrismLibrary/Prism/) so you can get started right away with Prism for Avalonia!
+Prism.Avalonia's logic and development approach is **similar** to that of [Prism for WPF](https://github.com/PrismLibrary/Prism/) so you can get started right away with Prism for Avalonia! Keep in mind, they are **similar** and not 1-to-1.
 
 ## Changes
 

--- a/Upgrading-to-Avalonia-11.md
+++ b/Upgrading-to-Avalonia-11.md
@@ -4,6 +4,11 @@ This document outlines the path to upgrading your projects from Avalonia v0.10.1
 
 Check out Avalonia's [Breaking Changes](https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes) wiki page for more information
 
+* https://github.com/AvaloniaUI/Avalonia/compare/release/11.0.0-preview4...release/11.0.0-preview5
+* https://github.com/AvaloniaUI/Avalonia/compare/11.0.0-preview3...11.0.0-preview4
+* https://github.com/AvaloniaUI/Avalonia/compare/11.0.0-preview2...11.0.0-preview3
+* https://github.com/AvaloniaUI/Avalonia/compare/11.0.0-preview1...11.0.0-preview2
+
 ## 11.0 Preview 5
 
 * NEW: IDialogWindow now implements `WindowClosingEventArgs`.
@@ -15,10 +20,37 @@ Check out Avalonia's [Breaking Changes](https://github.com/AvaloniaUI/Avalonia/w
 * Avalonia.ReactiveUI.Events.
   * See, [PR #5423](https://github.com/AvaloniaUI/Avalonia/pull/5423)
 * Themes: Both Avalonia.Themes.Fluent and Avalonia.Themes.Simple (formally, Default) are not a part of the main Avalonia nuget package anymore. You need to add a PackageReference to include either of these packages or both. For more details, see #5593
+* [WindowNotificationManager Pop-Ups are no longer working in 11 Preview 5](https://github.com/AvaloniaUI/Avalonia/issues/10216)
+  * See, [PR #9277](https://github.com/AvaloniaUI/Avalonia/pull/9277)
+  * The call to make the case was for "single view platforms" and not just Desktops which have a `Window` object. Example of the new implementation below.
+
+### WindowNotificationManager Example
+
+Previously, users had to set the HostWindow inside the main shell Window as you see below. Now, users can define this from any UserControl view by simply providing `notifyService.SetHostWindow(TopLevel.GetTopLevel(this))` in the view's .axaml.cs `override void OnAttachedToVisualTree(..)` method.
+
+```cs
+public partial class DashboardView : UserControl
+{
+  public DashboardView()
+  {
+    InitializeComponent();
+  }
+
+  protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+  {
+    base.OnAttachedToVisualTree(e);
+
+    // Initialize the WindowNotificationManager with the MainWindow
+    var notifyService = ContainerLocator.Current.Resolve<INotificationService>();
+    notifyService.SetHostWindow(TopLevel.GetTopLevel(this));
+  }
+}
+
+```
 
 ### Known Issues
 
-* [WindowNotificationManager Pop-Ups are no longer working in 11 Preview 5](https://github.com/AvaloniaUI/Avalonia/issues/10216)
+
 * Themes in sample are showing up cloudy
 * Selected ListView item still appears after clearing the List
   * **STATUS:** _Needs reported_

--- a/Upgrading-to-Avalonia-11.md
+++ b/Upgrading-to-Avalonia-11.md
@@ -11,18 +11,30 @@ Check out Avalonia's [Breaking Changes](https://github.com/AvaloniaUI/Avalonia/w
 
 ## 11.0 Preview 5
 
-* NEW: IDialogWindow now implements `WindowClosingEventArgs`.
-  * See, [Issue #9524](https://github.com/AvaloniaUI/Avalonia/issues/9524), [PR #9715](https://github.com/AvaloniaUI/Avalonia/pull/9715)
-  * This affects `IDialogWindow` implementation of `public event EventHandler<WindowClosingEventArgs>? Closing;`
+**NOTE:** Breaking Changes Ahead!
+
+### Breaking Changes
+
+[Breaking Changes](https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes) wiki
+
 * Deprecation of redundant interfaces.
   * See, [PR #9553](https://github.com/AvaloniaUI/Avalonia/pull/9553)
   * I.E. `IAvaloniaObject` -> `AvalonObject`, and more.
-* Avalonia.ReactiveUI.Events.
-  * See, [PR #5423](https://github.com/AvaloniaUI/Avalonia/pull/5423)
-* Themes: Both Avalonia.Themes.Fluent and Avalonia.Themes.Simple (formally, Default) are not a part of the main Avalonia nuget package anymore. You need to add a PackageReference to include either of these packages or both. For more details, see #5593
 * [WindowNotificationManager Pop-Ups are no longer working in 11 Preview 5](https://github.com/AvaloniaUI/Avalonia/issues/10216)
   * See, [PR #9277](https://github.com/AvaloniaUI/Avalonia/pull/9277)
-  * The call to make the case was for "single view platforms" and not just Desktops which have a `Window` object. Example of the new implementation below.
+  * **Example below**
+  * The call to make the case was for "_single view platforms_" and not just Desktops which have a `Window` object. Example of the new implementation below.
+* Themes:
+  * Both Avalonia.Themes.Fluent and Avalonia.Themes.Simple (formally, Default) are not a part of the main Avalonia nuget package anymore. You need to add a PackageReference to include either of these packages or both. For more details, see #5593
+  * Its been observed that when setting a background image in your control or window, all of the controls will appear cloudy.  _Upgrade or defect?_
+
+### Updates
+
+* NEW: IDialogWindow now implements `WindowClosingEventArgs`.
+  * See, [Issue #9524](https://github.com/AvaloniaUI/Avalonia/issues/9524), [PR #9715](https://github.com/AvaloniaUI/Avalonia/pull/9715)
+  * This affects `IDialogWindow` implementation of `public event EventHandler<WindowClosingEventArgs>? Closing;`
+* Avalonia.ReactiveUI.Events.
+  * See, [PR #5423](https://github.com/AvaloniaUI/Avalonia/pull/5423)
 
 ### WindowNotificationManager Example
 

--- a/build/Base.props
+++ b/build/Base.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>8.1.97.3-preview.11.5</Version>
+    <Version>8.1.97.4-preview.11.5</Version>
     <PackageProjectUrl>https://github.com/AvaloniaCommunity/Prism.Avalonia</PackageProjectUrl>
     <Copyright>Copyright (c) 2023 Avalonia Community</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/samples/SampleMvvmApp/Services/INotifictionService.cs
+++ b/samples/SampleMvvmApp/Services/INotifictionService.cs
@@ -7,7 +7,7 @@ namespace SampleMvvmApp.Services
     {
         int NotificationTimeout { get; set; }
 
-        void SetHostWindow(Window window);
+        void SetHostWindow(TopLevel window);
 
         void Show(string title, string message, Action? onClick = null);
     }

--- a/samples/SampleMvvmApp/Services/NotifictionService.cs
+++ b/samples/SampleMvvmApp/Services/NotifictionService.cs
@@ -21,7 +21,7 @@ namespace SampleMvvmApp.Services
 
         /// <summary>Set the host window.</summary>
         /// <param name="hostWindow">Parent window.</param>
-        public void SetHostWindow(Window hostWindow)
+        public void SetHostWindow(TopLevel hostWindow)
         {
             var notificationManager = new WindowNotificationManager(hostWindow)
             {

--- a/samples/SampleMvvmApp/ViewModels/DashboardViewModel.cs
+++ b/samples/SampleMvvmApp/ViewModels/DashboardViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Avalonia.Controls;
 using Avalonia.Threading;
 using Prism.Commands;
 using Prism.Regions;

--- a/samples/SampleMvvmApp/Views/DashboardView.axaml.cs
+++ b/samples/SampleMvvmApp/Views/DashboardView.axaml.cs
@@ -17,7 +17,7 @@ public partial class DashboardView : UserControl
     {
         base.OnAttachedToVisualTree(e);
 
-        // Initialize the WindowNotificationManager with the MainWindow
+        // Initialize the WindowNotificationManager with the "TopLevel". Previously (v0.10), MainWindow
         var notifyService = ContainerLocator.Current.Resolve<INotificationService>();
         notifyService.SetHostWindow(TopLevel.GetTopLevel(this));
     }

--- a/samples/SampleMvvmApp/Views/DashboardView.axaml.cs
+++ b/samples/SampleMvvmApp/Views/DashboardView.axaml.cs
@@ -1,5 +1,7 @@
-﻿using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+﻿using Avalonia;
+using Avalonia.Controls;
+using Prism.Ioc;
+using SampleMvvmApp.Services;
 
 namespace SampleMvvmApp.Views;
 
@@ -9,5 +11,14 @@ public partial class DashboardView : UserControl
     public DashboardView()
     {
         InitializeComponent();
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+
+        // Initialize the WindowNotificationManager with the MainWindow
+        var notifyService = ContainerLocator.Current.Resolve<INotificationService>();
+        notifyService.SetHostWindow(TopLevel.GetTopLevel(this));
     }
 }

--- a/samples/SampleMvvmApp/Views/MainWindow.axaml.cs
+++ b/samples/SampleMvvmApp/Views/MainWindow.axaml.cs
@@ -15,9 +15,11 @@ public partial class MainWindow : Window
 #endif
 
         // Avalonia v11-Preview 5 Breaking Change:
-        //  Previously, users had to set the HostWindow inside the main shell Window
-        //  as you see below. Now, users can define this from any UserControl view
-        //  by simply providing `notifyService.SetHostWindow(TopLevel.GetTopLevel(this))`
+        //  This code has moved to 'DashboardView.axaml.cs
+        //
+        //  In v0.10.x, users set the HostWindow inside the main shell Window passing 'this'
+        //  As of v11, the initialization no longer works from MainWindow and must be defined
+        //  in the UserControl by providing `notifyService.SetHostWindow(TopLevel.GetTopLevel(this))`
         //  in the view's .axaml.cs `override void OnAttachedToVisualTree(..)` method.
         //
         // OLD: Avalonia v0.10.18

--- a/samples/SampleMvvmApp/Views/MainWindow.axaml.cs
+++ b/samples/SampleMvvmApp/Views/MainWindow.axaml.cs
@@ -1,6 +1,5 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Prism.Ioc;
 using SampleMvvmApp.Services;
 
@@ -15,8 +14,15 @@ public partial class MainWindow : Window
         this.AttachDevTools();
 #endif
 
-        // Initialize the WindowNotificationManager with the MainWindow
-        var notifyService = ContainerLocator.Current.Resolve<INotificationService>();
-        notifyService.SetHostWindow(this);
+        // Avalonia v11-Preview 5 Breaking Change:
+        //  Previously, users had to set the HostWindow inside the main shell Window
+        //  as you see below. Now, users can define this from any UserControl view
+        //  by simply providing `notifyService.SetHostWindow(TopLevel.GetTopLevel(this))`
+        //  in the view's .axaml.cs `override void OnAttachedToVisualTree(..)` method.
+        //
+        // OLD: Avalonia v0.10.18
+        ////// Initialize the WindowNotificationManager with the MainWindow
+        ////var notifyService = ContainerLocator.Current.Resolve<INotificationService>();
+        ////notifyService.SetHostWindow(this);
     }
 }


### PR DESCRIPTION
## Feature Includes

* Upgrade Window Notification Manager Pop-Up example
* Breaking change in Avalonia [PR 9277](https://github.com/AvaloniaUI/Avalonia/pull/9277) for more information

## What Changed

The reason for the change was to provide support for single-view platforms, where a "desktop" window is not available.

Developers can no longer initialize the `WindowNotificationManager` in the main (shell) window's .axaml.cs, nor pass in main window's instance (`this`).

## New Implementation

The initialization must now be performed in your UserControl's .axaml.cs file. The sample below is borrowed from the **SampleMvvmApp** which uses a `NotificationService`

```cs
    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
    {
        base.OnAttachedToVisualTree(e);

        // Initialize the WindowNotificationManager with the "TopLevel" and no longer the MainWindow
        var notifyService = ContainerLocator.Current.Resolve<INotificationService>();
        notifyService.SetHostWindow(TopLevel.GetTopLevel(this));
    }
```