### PR TITLE
v11-Prev 5 - After Upgrading Prism Module Fails To Register Region

### DIFF
--- a/samples/ViewDiscovery/App.axaml.cs
+++ b/samples/ViewDiscovery/App.axaml.cs
@@ -3,8 +3,6 @@ using Avalonia;
 using Avalonia.Markup.Xaml;
 using Prism.DryIoc;
 using Prism.Ioc;
-using Prism.Regions;
-using ViewDiscovery.ViewModels;
 using ViewDiscovery.Views;
 
 namespace ViewDiscovery;
@@ -13,7 +11,7 @@ public class App : PrismApplication
 {
     public App()
     {
-        Console.WriteLine("Constructor()");
+        System.Diagnostics.Debug.WriteLine("App.Constructor()");
     }
 
     public override void Initialize()
@@ -25,10 +23,8 @@ public class App : PrismApplication
 
     protected override void RegisterTypes(IContainerRegistry containerRegistry)
     {
+        System.Diagnostics.Debug.WriteLine("RegisterTypes(...)");
         // Wire-up services and navigation Views here.
-        System.Diagnostics.Debug.WriteLine("RegisterTypes()");
-        containerRegistry.RegisterForNavigation<ViewA, ViewAViewModel>();
-        containerRegistry.RegisterForNavigation<ViewB, ViewBViewModel>();
     }
 
     /// <summary>User interface entry point, called after Register and ConfigureModules.</summary>
@@ -43,8 +39,13 @@ public class App : PrismApplication
     {
         System.Diagnostics.Debug.WriteLine("OnInitialized()");
 
-        var regionManager = Container.Resolve<IRegionManager>();
-        regionManager.RegisterViewWithRegion(RegionNames.ContentRegion, typeof(ViewA));
-        regionManager.RegisterViewWithRegion(RegionNames.ContentRegion, typeof(ViewB));
+        // Alternative Approach:
+        //  Instead of registering the Views in the MainWindow (as this samples does),
+        //  you can register them here in OnInitialized(), or CreateShell(), or RegisterTypes(..)
+        //  by resolving the `IRegionManager` from the container.
+        //
+        ////var regionManager = Container.Resolve<IRegionManager>();
+        ////regionManager.RegisterViewWithRegion(RegionNames.ContentRegion, typeof(ViewA));
+        ////regionManager.RegisterViewWithRegion(RegionNames.ContentRegion, typeof(ViewB));
     }
 }

--- a/samples/ViewDiscovery/Views/MainWindow.axaml
+++ b/samples/ViewDiscovery/Views/MainWindow.axaml
@@ -2,13 +2,16 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:core="using:ViewDiscovery"
         xmlns:prism="http://prismlibrary.com/"
-        Title="Shell" Height="350" Width="525"
+        prism:ViewModelLocator.AutoWireViewModel="True"
+        Title="View Discovery Sample" Height="350" Width="525"
         x:CompileBindings="True"
         x:Class="ViewDiscovery.Views.MainWindow">
   <Panel>
     <Grid>
-      <ContentControl prism:RegionManager.RegionName="ContentRegion" />
+      <!--<ContentControl prism:RegionManager.RegionName="ContentRegion" />-->
+      <ContentControl prism:RegionManager.RegionName="{x:Static core:RegionNames.ContentRegion}" />
     </Grid>
   </Panel>
 </Window>

--- a/src/Prism.Avalonia/Regions/ItemsControlRegionAdapter.cs
+++ b/src/Prism.Avalonia/Regions/ItemsControlRegionAdapter.cs
@@ -49,6 +49,9 @@ namespace Prism.Regions
                 }
             }
 
+            // ISSUE: Avalonia v11-Preview5 Throws an error here (ModulesSampleApp)
+            // ERROR: ...
+            // FIX: ?? IRegion needs to implement IList (what change in v11-preview would cause this?)
             regionTarget.Items = region.Views;
         }
 

--- a/src/Prism.Avalonia/Regions/ItemsControlRegionAdapter.cs
+++ b/src/Prism.Avalonia/Regions/ItemsControlRegionAdapter.cs
@@ -49,10 +49,8 @@ namespace Prism.Regions
                 }
             }
 
-            // ISSUE: Avalonia v11-Preview5 Throws an error here (ModulesSampleApp)
-            // ERROR: ...
-            // FIX: ?? IRegion needs to implement IList (what change in v11-preview would cause this?)
-            regionTarget.Items = region.Views;
+            // Avalonia v11-Preview5 needs IRegion implement IList. Enforcing it to return AvaloniaList<object> fixes this.
+            regionTarget.Items = region.Views as Avalonia.Collections.AvaloniaList<object>;
         }
 
         /// <summary>


### PR DESCRIPTION
## Issue

After upgrading to Avalonia v11-Preview5, Prism Modules can fail to register a region defined in XAML.

The error is being thrown in `ItemsControlRegionAdapter.Adapt(IRegion region, ItemsControl regionTarget)` when it attempts to set `regionTarget.Items = region.Views;`. Which is equivalent to `Avalonia.Collections.AvaloniaList<object> = Prism.Regions.ViewsCollection`.  To address this, `IViewsCollection` may need to inherit `IList` (_by why all a sudden?_)

```xaml
  <!-- DummyModuleView2.axaml -->
  <ItemsControl prismRegions:RegionManager.RegionName="ListRegion"></ItemsControl>
```

## Reproduce

1. Pull latest Develop branch
2. Set sample app, **ModuleSampleApp** as Startup Project
3. Run the code
4. _The above error will be thrown before the window renders_

## Research
Currently, I'm looking into what changed in the architecture to warrant this modification. This could be why the sample app, ViewDiscovery, is also failing to operate correctly

**Error Message:**
> Prism.Regions.Behaviors.RegionCreationException: 'An exception occurred while creating a region with name 'ListRegion'. The exception was: System.ArgumentException: Collection implements INotifyCollectionChanged but not IList. (Parameter 'source')

**Call Stack:**
```
This exception was originally thrown at this call stack:
    Avalonia.Controls.ItemsSourceView.ItemsSourceView(System.Collections.IEnumerable) in ItemsSourceView.cs
    Avalonia.Controls.ItemsSourceView.GetOrCreate(System.Collections.IEnumerable) in ItemsSourceView.cs
    Avalonia.Controls.ItemsControl.OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs) in ItemsControl.cs
    Avalonia.Animation.Animatable.OnPropertyChangedCore(Avalonia.AvaloniaPropertyChangedEventArgs) in Animatable.cs
    Avalonia.Controls.ItemsControl.Items.set(System.Collections.IEnumerable) in ItemsControl.cs
    Prism.Regions.ItemsControlRegionAdapter.Adapt(Prism.Regions.IRegion, Avalonia.Controls.ItemsControl) in ItemsControlRegionAdapter.cs
    Prism.Regions.RegionAdapterBase<T>.Initialize(T, string) in RegionAdapterBase.cs
    Prism.Regions.RegionAdapterBase<T>.Prism.Regions.IRegionAdapter.Initialize(object, string) in RegionAdapterBase.cs
    Prism.Regions.Behaviors.DelayedRegionCreationBehavior.CreateRegion(Avalonia.AvaloniaObject, string) in DelayedRegionCreationBehavior.cs
```

## References
* https://github.com/AvaloniaUI/Avalonia/commit/3195df0910a7c1b44a770624b5eb5e461485f205
* https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ItemsControl.cs