### PR TITLE
Upgrade to v11.0.0 - Preview 8

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 Change log history for Prism.Avalonia
 
+## v8.1.97.11-preview.11.8 (2023-05-31)
+
+* Update: Converted ItemsControlRegionAdapter to use `ItemsSource` instead of `Items`
+  * As of Avalonia PR [#10827](https://github.com/AvaloniaUI/Avalonia/pull/10827), `ItemsControl.Items` is readonly and should use `ItemsControls.ItemsSource` (PR [#10590](https://github.com/AvaloniaUI/Avalonia/pull/10590))
+
 ## v8.1.97.4-preview.11.5 (2022-02-??)
 
 * New: Support for Avalonia v11.0 Preview 5

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Choose the NuGet package version that matches your Avalonia version.
 |-|-|
 | 0.10.x          | 8.1.97.2
 | 11.0 Preview 4  | 8.1.97.3-preview.11.4
-| 11.0 Preview 5  | 8.1.97.4-preview.11.5)
-| 11.0 Preview 6  | 8.1.97.5-preview.11.6 (_COMING SOON_)
+| 11.0 Preview 5  | 8.1.97.4-preview.11.5
+| 11.0 Preview 8  | 8.1.97.11-preview.11.8
 
 Be sure to check out the [ChangeLog.md](ChangeLog.md) and [Upgrading-to-Avalonia-11.md](Upgrading-to-Avalonia-11.md) when upgrading your NuGet packages
 
@@ -31,9 +31,9 @@ Add the Prism.Avalonia and its DryIoc packages to your project:
 Install-Package Prism.Avalonia -Version 8.1.97.2
 Install-Package Prism.DryIoc.Avalonia -Version 8.1.97.2
 
-# Avalonia v11-preview5
-Install-Package Prism.Avalonia -Version 8.1.97.4-preview.11.5
-Install-Package Prism.DryIoc.Avalonia -Version 8.1.97.4-preview.11.5
+# Avalonia v11-preview8
+Install-Package Prism.Avalonia -Version 8.1.97.11-preview.11.8
+Install-Package Prism.DryIoc.Avalonia -Version 8.1.97.11-preview.11.8
 ```
 
 ## How to use

--- a/Upgrading-to-Avalonia-11.md
+++ b/Upgrading-to-Avalonia-11.md
@@ -4,10 +4,20 @@ This document outlines the path to upgrading your projects from Avalonia v0.10.1
 
 Check out Avalonia's [Breaking Changes](https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes) wiki page for more information
 
-* https://github.com/AvaloniaUI/Avalonia/compare/release/11.0.0-preview4...release/11.0.0-preview5
+* https://github.com/AvaloniaUI/Avalonia/compare/release/11.0.0-preview7...release/11.0.0-preview8 (_198 commits, 279 file changes_)
+* https://github.com/AvaloniaUI/Avalonia/compare/release/11.0.0-preview6...release/11.0.0-preview7  (_437 commits, 581 file changes_)
+* https://github.com/AvaloniaUI/Avalonia/compare/release/11.0.0-preview5...release/11.0.0-preview6 (_970 commits, 1,088 file changes_)
+* https://github.com/AvaloniaUI/Avalonia/compare/11.0.0-preview4...11.0.0-preview5
 * https://github.com/AvaloniaUI/Avalonia/compare/11.0.0-preview3...11.0.0-preview4
 * https://github.com/AvaloniaUI/Avalonia/compare/11.0.0-preview2...11.0.0-preview3
 * https://github.com/AvaloniaUI/Avalonia/compare/11.0.0-preview1...11.0.0-preview2
+
+## 11.0 Preview 8
+
+### Breaking Changes
+
+* Converted ItemsControlRegionAdapter to use ItemsSource.
+  * As of Avalonia PR [#10827](https://github.com/AvaloniaUI/Avalonia/pull/10827), `ItemsControl.Items` is readonly and should use `ItemsControls.ItemsSource` (PR [#10590](https://github.com/AvaloniaUI/Avalonia/pull/10590))
 
 ## 11.0 Preview 5
 
@@ -91,7 +101,6 @@ When using Fluent theme, you no longer has a `Mode` attribute.
   <FluentTheme Mode="Light" />
 ```
 
-
 ## 11.0 Preview 4
 
 ### DataTemplates
@@ -99,4 +108,3 @@ When using Fluent theme, you no longer has a `Mode` attribute.
 DataTemplates now require a `DataType` to be defined. This actually improves intellisense of your XAML and loading times with MVVM.
 
 As a workaround for ListViews, you can use the `ItemTemplate` which does not require the definition of a `DataType`.
-

--- a/build/AvaloniaDependency.props
+++ b/build/AvaloniaDependency.props
@@ -3,12 +3,12 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview6" />
-    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.0.0-preview6" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview6" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview8" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview8" />
+    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.0.0-preview8" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview8" />
     <!--
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-preview6" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-preview8" />
     -->
   </ItemGroup>
 

--- a/build/Base.props
+++ b/build/Base.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>8.1.97.4-preview.11.8</Version>
+    <Version>8.1.97.11-preview.11.8</Version>
     <PackageProjectUrl>https://github.com/AvaloniaCommunity/Prism.Avalonia</PackageProjectUrl>
     <Copyright>Copyright (c) 2023 Avalonia Community</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/build/Base.props
+++ b/build/Base.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>8.1.97.4-preview.11.5</Version>
+    <Version>8.1.97.4-preview.11.8</Version>
     <PackageProjectUrl>https://github.com/AvaloniaCommunity/Prism.Avalonia</PackageProjectUrl>
     <Copyright>Copyright (c) 2023 Avalonia Community</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/build/Nuget.props
+++ b/build/Nuget.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReleaseNotes>* Upgraded to support Avalonia v11.0.0-preview8</PackageReleaseNotes>
   </PropertyGroup>
   
 </Project>

--- a/build/SampleApp.props
+++ b/build/SampleApp.props
@@ -6,11 +6,11 @@
   <Import Project="AvaloniaDependency.props" />
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview6" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview8" />
     <!--<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview5" />-->
-    <PackageReference Include="Avalonia.LinuxFramebuffer" Version="11.0.0-preview6" />
-    <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-preview6" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview6" />
+    <PackageReference Include="Avalonia.LinuxFramebuffer" Version="11.0.0-preview8" />
+    <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-preview8" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview8" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\Prism.DryIoc.Avalonia\Prism.DryIoc.Avalonia.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/SampleMvvmApp/Views/DashboardView.axaml
+++ b/samples/SampleMvvmApp/Views/DashboardView.axaml
@@ -30,7 +30,7 @@
 
       <ComboBox VerticalAlignment="Center"
                 HorizontalAlignment="Stretch"
-                Items="{Binding ThemeStyles}"
+                ItemsSource="{Binding ThemeStyles}"
                 SelectedItem="{Binding ThemeSelected}">
         <!--SelectedIndex="{Binding ThemeSelectedIndex}" >-->
         <ComboBox.ItemTemplate>
@@ -51,7 +51,7 @@
 
     <ListBox Grid.Row="3"
              Margin="2"
-             Items="{Binding ListItems}"
+             ItemsSource="{Binding ListItems}"
              ScrollViewer.HorizontalScrollBarVisibility="Visible"
              ScrollViewer.VerticalScrollBarVisibility="Visible"
              SelectedIndex="{Binding ListItemSelected}"

--- a/src/Prism.Avalonia/Prism.Avalonia.csproj
+++ b/src/Prism.Avalonia/Prism.Avalonia.csproj
@@ -17,8 +17,6 @@ Prism.Avalonia helps you more easily design and build rich, flexible, and easy t
     <Authors>Damian Suess, Omid Mafakher, various contributors</Authors>
     <Title>Prism.Avalonia</Title>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>* Upgraded to support Avalonia v11.0.0-preview5
-</PackageReleaseNotes>
     <PackageIcon>Prism.Avalonia.png</PackageIcon>
   </PropertyGroup>
 

--- a/src/Prism.Avalonia/Regions/ItemsControlRegionAdapter.cs
+++ b/src/Prism.Avalonia/Regions/ItemsControlRegionAdapter.cs
@@ -50,7 +50,12 @@ namespace Prism.Regions
             }
 
             // Avalonia v11-Preview5 needs IRegion implement IList. Enforcing it to return AvaloniaList<object> fixes this.
-            regionTarget.Items = region.Views as Avalonia.Collections.AvaloniaList<object>;
+            // Avalonia v11-Preview8 ItemsControl.Items is readonly.
+            ////regionTarget.Items = region.Views as Avalonia.Collections.AvaloniaList<object>;
+            foreach (var item in region.Views as Avalonia.Collections.AvaloniaList<object>)
+            {
+                regionTarget.Items.Add(item);
+            }
         }
 
         /// <summary>

--- a/src/Prism.Avalonia/Regions/ItemsControlRegionAdapter.cs
+++ b/src/Prism.Avalonia/Regions/ItemsControlRegionAdapter.cs
@@ -50,12 +50,9 @@ namespace Prism.Regions
             }
 
             // Avalonia v11-Preview5 needs IRegion implement IList. Enforcing it to return AvaloniaList<object> fixes this.
-            // Avalonia v11-Preview8 ItemsControl.Items is readonly.
+            // Avalonia v11-Preview8 ItemsControl.Items is readonly (#10827).
             ////regionTarget.Items = region.Views as Avalonia.Collections.AvaloniaList<object>;
-            foreach (var item in region.Views as Avalonia.Collections.AvaloniaList<object>)
-            {
-                regionTarget.Items.Add(item);
-            }
+            regionTarget.ItemsSource = region.Views as Avalonia.Collections.AvaloniaList<object>;
         }
 
         /// <summary>

--- a/src/Prism.Avalonia/Regions/Region.cs
+++ b/src/Prism.Avalonia/Regions/Region.cs
@@ -369,6 +369,7 @@ namespace Prism.Regions
                 {
                     throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, Resources.RegionViewNameExistsException, viewName));
                 }
+
                 itemMetadata.Name = viewName;
             }
 

--- a/src/Prism.DryIoc.Avalonia/Prism.DryIoc.Avalonia.csproj
+++ b/src/Prism.DryIoc.Avalonia/Prism.DryIoc.Avalonia.csproj
@@ -13,7 +13,6 @@
     <Copyright>Copyright (c) 2023 Avalonia Community</Copyright>
     <Title>Prism.DryIoc.Avalonia</Title>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>* Upgraded to support Avalonia v11.0.0-preview5</PackageReleaseNotes>
     <PackageTags>prism;mvvm;xaml;avalonia;dryioc;dependencyinjection;navigation;dialog;prismavalonia;</PackageTags>
     <PackageIcon>Prism.Avalonia.png</PackageIcon>
   </PropertyGroup>

--- a/tests/Avalonia/Prism.Avalonia.Tests/Mocks/Views/MockBindingsView.axaml
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Mocks/Views/MockBindingsView.axaml
@@ -10,7 +10,7 @@
   <StackPanel>
     <ListBox Margin="2"
            VerticalAlignment="Bottom"
-           Items="{Binding ListItems}"
+           ItemsSource="{Binding ListItems}"
            ScrollViewer.HorizontalScrollBarVisibility="Visible"
            ScrollViewer.VerticalScrollBarVisibility="Visible"
            SelectedIndex="{Binding ListItemSelected}"


### PR DESCRIPTION
## Feature Includes
* Upgraded Avalonia NuGet to v11.0.0-preview8.
* Moved NuGet package notes to props file

## In Progress:
* [x] Resolve `AvaloniaStatsTask`
* [x] Resolve build failures caused by the v11.0.0-Preview8 implementation
    * [x] _Unable to find suitable setter or adder for property Items of type ...ItemsControl_
* [x] Review areas of improvement

## Issues

* https://github.com/AvaloniaUI/Avalonia/issues/11308
  * 🆕 https://github.com/AvaloniaUI/Avalonia/wiki/Telemetry
  * https://github.com/AvaloniaUI/Avalonia/pull/11116

### References
* [Discussion - Upgrade v11.0.0-Preview 8](https://github.com/AvaloniaCommunity/Prism.Avalonia/discussions/62)