### PR TITLE
Remove Avalonia.Desktop dependency from Core

### DIFF
--- a/build/AvaloniaDependency.props
+++ b/build/AvaloniaDependency.props
@@ -1,15 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build"
-         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.0.0-preview8" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview8" />
     <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.0.0-preview8" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview8" />
-    <!--
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-preview8" />
-    -->
   </ItemGroup>
 
 </Project>

--- a/build/Base.props
+++ b/build/Base.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>8.1.97.11-preview.11.8</Version>
+    <Version>8.1.97.11-preview.11.8.1</Version>
     <PackageProjectUrl>https://github.com/AvaloniaCommunity/Prism.Avalonia</PackageProjectUrl>
     <Copyright>Copyright (c) 2023 Avalonia Community</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/build/SampleApp.props
+++ b/build/SampleApp.props
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview8" />
     <!--<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview5" />-->
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview8" />
     <PackageReference Include="Avalonia.LinuxFramebuffer" Version="11.0.0-preview8" />
     <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-preview8" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview8" />


### PR DESCRIPTION
Moved Avalonia.Desktop package reference to `SampleApp.props`. This file is used for the desktop sample applications and not the core Prism.Avalonia library.

References #55 