### PR TITLE
DialogService Host Window

### DIFF
--- a/samples/SampleDialogApp/ViewModels/MessageBoxViewModel.cs
+++ b/samples/SampleDialogApp/ViewModels/MessageBoxViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Prism.Commands;
 using Prism.Mvvm;
-using Prism.Regions;
 using Prism.Services.Dialogs;
 
 namespace SampleDialogApp.ViewModels;

--- a/samples/SampleDialogApp/Views/DialogView.axaml
+++ b/samples/SampleDialogApp/Views/DialogView.axaml
@@ -8,26 +8,37 @@
              Height="200" Width="400"
              x:Class="SampleDialogApp.Views.DialogView">
   <StackPanel HorizontalAlignment="Center" Spacing=" 5">
-    <Label Content="{Binding Title}" FontWeight="Bold" />
+    <!--<Label Content="{Binding Title}" FontWeight="Bold" />-->
+
+    <Label Content="Show Modal Dialog:" />
+    <StackPanel Orientation="Horizontal" Spacing="5">
+      <Button Content="Modal from .AXAML.CS" Click="BtnShowModal_Click" />
+      <Button Content="Modal from MVVM" Command="{Binding CmdModalDialog}" />
+    </StackPanel>
 
     <StackPanel Orientation="Horizontal">
       <Label Content="Custom Param:" />
       <Label Content="{Binding CustomMessage}" />
     </StackPanel>
 
-    <StackPanel Orientation="Horizontal" Spacing="5">
-        <Button Content="None" Command="{Binding CmdResult}" CommandParameter="0" />
-        <Button Content="OK" Command="{Binding CmdResult}" CommandParameter="1" />
-        <Button Content="Cancel" Command="{Binding CmdResult}" CommandParameter="2" />
-      </StackPanel>
-      <StackPanel Orientation="Horizontal" Spacing="5">
-        <Button Content="Abort" Command="{Binding CmdResult}" CommandParameter="3" />
-        <Button Content="Retry" Command="{Binding CmdResult}" CommandParameter="4" />
-        <Button Content="Ignore" Command="{Binding CmdResult}" CommandParameter="5" />
-      </StackPanel>
-      <StackPanel Orientation="Horizontal" Spacing="5">
-        <Button Content="Yes" Command="{Binding CmdResult}" CommandParameter="6" />
-        <Button Content="No" Command="{Binding CmdResult}" CommandParameter="7" />
-      </StackPanel>
+    <Grid RowDefinitions="auto,auto,auto" ColumnDefinitions="auto,auto,auto">
+      <Grid.Styles>
+        <Style Selector="Button">
+          <Setter Property="HorizontalAlignment" Value="Stretch" />
+          <Setter Property="Margin" Value="2" />
+        </Style>
+      </Grid.Styles>
+
+      <Button Grid.Row="0" Grid.Column="0" Content="None" Command="{Binding CmdResult}" CommandParameter="0" />
+      <Button Grid.Row="0" Grid.Column="1" Content="OK" Command="{Binding CmdResult}" CommandParameter="1" />
+      <Button Grid.Row="0" Grid.Column="2" Content="Cancel" Command="{Binding CmdResult}" CommandParameter="2" />
+
+      <Button Grid.Row="1" Grid.Column="0" Content="Abort" Command="{Binding CmdResult}" CommandParameter="3" />
+      <Button Grid.Row="1" Grid.Column="1" Content="Retry" Command="{Binding CmdResult}" CommandParameter="4" />
+      <Button Grid.Row="1" Grid.Column="2" Content="Ignore" Command="{Binding CmdResult}" CommandParameter="5" />
+
+      <Button Grid.Row="2" Grid.Column="0" Content="Yes" Command="{Binding CmdResult}" CommandParameter="6" />
+      <Button Grid.Row="2" Grid.Column="1" Content="No" Command="{Binding CmdResult}" CommandParameter="7" />
+    </Grid>
   </StackPanel>
 </UserControl>

--- a/samples/SampleDialogApp/Views/DialogView.axaml.cs
+++ b/samples/SampleDialogApp/Views/DialogView.axaml.cs
@@ -1,18 +1,50 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using Prism.Ioc;
+using Prism.Services.Dialogs;
+using SampleDialogApp.ViewModels;
 
-namespace SampleDialogApp.Views
+namespace SampleDialogApp.Views;
+
+public partial class DialogView : UserControl
 {
-    public partial class DialogView : UserControl
+    public DialogView()
     {
-        public DialogView()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
+    }
 
-        ////private void InitializeComponent()
-        ////{
-        ////    AvaloniaXamlLoader.Load(this);
-        ////}
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        // Pass the parent window to the ViewModel
+        // given that the ViewModel has been binded to this view
+        DialogViewModel? viewModel = this.DataContext as DialogViewModel;
+        if (this.Parent is Window parent &&
+            viewModel is not null)
+        {
+            viewModel.ParentWindow = parent;
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void BtnShowModal_Click(object sender, RoutedEventArgs args)
+    {
+        var dialogSvc = ContainerLocator.Current.Resolve<IDialogService>();
+
+        var title = "MessageBox Title Here";
+        var message = "Hello, I am a simple modal MessageBox with an OK button.\n\n" +
+                      "I've been called by the `.axaml.cs` UserControl.";
+
+        dialogSvc.ShowDialog(
+            this.Parent as Window,
+            nameof(MessageBoxView),
+            new DialogParameters($"title={title}&message={message}"),
+            r => { });
     }
 }

--- a/src/Prism.Avalonia/Services/Dialogs/IDialogService.cs
+++ b/src/Prism.Avalonia/Services/Dialogs/IDialogService.cs
@@ -3,43 +3,40 @@ using Avalonia.Controls;
 
 namespace Prism.Services.Dialogs
 {
-    /// <summary>
-    /// Interface to show modal and non-modal dialogs.
-    /// </summary>
+    /// <summary>Interface to show modal and non-modal dialogs.</summary>
     public interface IDialogService
     {
-        /// <summary>
-        /// Shows a non-modal dialog.
-        /// </summary>
+        /// <summary>Shows a non-modal dialog.</summary>
         /// <param name="name">The name of the dialog to show.</param>
         /// <param name="parameters">The parameters to pass to the dialog.</param>
         /// <param name="callback">The action to perform when the dialog is closed.</param>
         void Show(string name, IDialogParameters parameters, Action<IDialogResult> callback);
 
-        /// <summary>
-        /// Shows a non-modal dialog.
-        /// </summary>
+        /// <summary>Shows a non-modal dialog.</summary>
         /// <param name="name">The name of the dialog to show.</param>
         /// <param name="parameters">The parameters to pass to the dialog.</param>
         /// <param name="callback">The action to perform when the dialog is closed.</param>
         /// <param name="windowName">The name of the hosting window registered with the IContainerRegistry.</param>
         void Show(string name, IDialogParameters parameters, Action<IDialogResult> callback, string windowName);
 
-        /// <summary>
-        /// Shows a modal dialog.
-        /// </summary>
+        /// <summary>Shows a modal dialog.</summary>
         /// <param name="name">The name of the dialog to show.</param>
         /// <param name="parameters">The parameters to pass to the dialog.</param>
         /// <param name="callback">The action to perform when the dialog is closed.</param>
         void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback);
 
-        /// <summary>
-        /// Shows a modal dialog.
-        /// </summary>
+        /// <summary>Shows a modal dialog.</summary>
         /// <param name="name">The name of the dialog to show.</param>
         /// <param name="parameters">The parameters to pass to the dialog.</param>
         /// <param name="callback">The action to perform when the dialog is closed.</param>
         /// <param name="windowName">The name of the hosting window registered with the IContainerRegistry.</param>
         void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback, string windowName);
+
+        /// <summary>Shows a modal dialog attached to the defined parent.</summary>
+        /// <param name="owner">The optional host window of the modal dialog.</param>
+        /// <param name="name">The name of the dialog to show.</param>
+        /// <param name="parameters">The parameters to pass to the dialog.</param>
+        /// <param name="callback">The action to perform when the dialog is closed.</param>
+        void ShowDialog(Window owner, string name, IDialogParameters parameters, Action<IDialogResult> callback);
     }
 }


### PR DESCRIPTION
## Feature Includes
* Merge pull request #75 from AvaloniaCommunity/feature/Avalonia-v10-DialogHostWindow
* The DialogService now allows for the parent window to be optionally specified
  * When not provided, the main window will be used by default
