### PR TITLE
Removed nesting levels through block-scoped `using`s

### DIFF
--- a/tests/Avalonia/Prism.Avalonia.Tests/CompilerHelper.Desktop.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/CompilerHelper.Desktop.cs
@@ -53,19 +53,18 @@ namespace Prism.Avalonia.Tests
             CSharpCodeProvider codeProvider = new CSharpCodeProvider();
             CompilerParameters cp = new CompilerParameters(referencedAssemblies.ToArray(), output);
 
-            using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(input))
-            {
-                if (stream == null)
-                {
-                    throw new ArgumentException("input");
-                }
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(input);
 
-                StreamReader reader = new StreamReader(stream);
-                string source = reader.ReadToEnd();
-                CompilerResults results = codeProvider.CompileAssemblyFromSource(cp, source);
-                ThrowIfCompilerError(results);
-                return results;
+            if (stream == null)
+            {
+                throw new ArgumentException("input");
             }
+
+            StreamReader reader = new StreamReader(stream);
+            string source = reader.ReadToEnd();
+            CompilerResults results = codeProvider.CompileAssemblyFromSource(cp, source);
+            ThrowIfCompilerError(results);
+            return results;
         }
 
         public static void CreateOutput(string output)

--- a/tests/Avalonia/Prism.Avalonia.Tests/Modularity/AssemblyResolverFixture.Desktop.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Modularity/AssemblyResolverFixture.Desktop.cs
@@ -1,4 +1,4 @@
-using Prism.Modularity;
+﻿using Prism.Modularity;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Modularity
@@ -21,43 +21,43 @@ namespace Prism.Avalonia.Tests.Modularity
         public void ShouldThrowOnInvalidAssemblyFilePath()
         {
             bool exceptionThrown = false;
-            using (var resolver = new AssemblyResolver())
+
+            using var resolver = new AssemblyResolver();
+
+            try
             {
-                try
-                {
-                    resolver.LoadAssemblyFrom(null);
-                }
-                catch (ArgumentException)
-                {
-                    exceptionThrown = true;
-                }
-
-                Assert.True(exceptionThrown);
-
-                try
-                {
-                    resolver.LoadAssemblyFrom("file://InexistentFile.dll");
-                    exceptionThrown = false;
-                }
-                catch (FileNotFoundException)
-                {
-                    exceptionThrown = true;
-                }
-
-                Assert.True(exceptionThrown);
-
-                try
-                {
-                    resolver.LoadAssemblyFrom("InvalidUri.dll");
-                    exceptionThrown = false;
-                }
-                catch (ArgumentException)
-                {
-                    exceptionThrown = true;
-                }
-
-                Assert.True(exceptionThrown);
+                resolver.LoadAssemblyFrom(null);
             }
+            catch (ArgumentException)
+            {
+                exceptionThrown = true;
+            }
+
+            Assert.True(exceptionThrown);
+
+            try
+            {
+                resolver.LoadAssemblyFrom("file://InexistentFile.dll");
+                exceptionThrown = false;
+            }
+            catch (FileNotFoundException)
+            {
+                exceptionThrown = true;
+            }
+
+            Assert.True(exceptionThrown);
+
+            try
+            {
+                resolver.LoadAssemblyFrom("InvalidUri.dll");
+                exceptionThrown = false;
+            }
+            catch (ArgumentException)
+            {
+                exceptionThrown = true;
+            }
+
+            Assert.True(exceptionThrown);
         }
 
         [Fact]
@@ -71,20 +71,20 @@ namespace Prism.Avalonia.Tests.Modularity
                 Path = Path.GetFullPath(assemblyPath)
             };
             var assemblyUri = uriBuilder.Uri;
-            using (var resolver = new AssemblyResolver())
-            {
-                Type resolvedType =
-                    Type.GetType(
-                        "TestModules.ModuleInLoadedFromContext1Class, ModuleInLoadedFromContext1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
-                Assert.Null(resolvedType);
 
-                resolver.LoadAssemblyFrom(assemblyUri.ToString());
+            using var resolver = new AssemblyResolver();
 
-                resolvedType =
-                    Type.GetType(
-                        "TestModules.ModuleInLoadedFromContext1Class, ModuleInLoadedFromContext1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
-                Assert.NotNull(resolvedType);
-            }
+            Type resolvedType =
+                Type.GetType(
+                    "TestModules.ModuleInLoadedFromContext1Class, ModuleInLoadedFromContext1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
+            Assert.Null(resolvedType);
+
+            resolver.LoadAssemblyFrom(assemblyUri.ToString());
+
+            resolvedType =
+                Type.GetType(
+                    "TestModules.ModuleInLoadedFromContext1Class, ModuleInLoadedFromContext1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
+            Assert.NotNull(resolvedType);
         }
 
         [Fact]
@@ -98,25 +98,25 @@ namespace Prism.Avalonia.Tests.Modularity
                 Path = Path.GetFullPath(assemblyPath)
             };
             var assemblyUri = uriBuilder.Uri;
-            using (var resolver = new AssemblyResolver())
-            {
-                resolver.LoadAssemblyFrom(assemblyUri.ToString());
 
-                Type resolvedType =
-                    Type.GetType("TestModules.ModuleInLoadedFromContext2Class, ModuleInLoadedFromContext2");
+            using var resolver = new AssemblyResolver();
 
-                Assert.NotNull(resolvedType);
+            resolver.LoadAssemblyFrom(assemblyUri.ToString());
 
-                resolvedType =
-                    Type.GetType("TestModules.ModuleInLoadedFromContext2Class, ModuleInLoadedFromContext2, Version=0.0.0.0");
+            Type resolvedType =
+                Type.GetType("TestModules.ModuleInLoadedFromContext2Class, ModuleInLoadedFromContext2");
 
-                Assert.NotNull(resolvedType);
+            Assert.NotNull(resolvedType);
 
-                resolvedType =
-                    Type.GetType("TestModules.ModuleInLoadedFromContext2Class, ModuleInLoadedFromContext2, Version=0.0.0.0, Culture=neutral");
+            resolvedType =
+                Type.GetType("TestModules.ModuleInLoadedFromContext2Class, ModuleInLoadedFromContext2, Version=0.0.0.0");
 
-                Assert.NotNull(resolvedType);
-            }
+            Assert.NotNull(resolvedType);
+
+            resolvedType =
+                Type.GetType("TestModules.ModuleInLoadedFromContext2Class, ModuleInLoadedFromContext2, Version=0.0.0.0, Culture=neutral");
+
+            Assert.NotNull(resolvedType);
         }
 
         public void Dispose()


### PR DESCRIPTION
# Background

.NET allows to initialize and properly dispose of `IDisposable` objects (usually objectd that handle external system resources whose structure is foreign to the runtime and have to be disposed of explicitly) through `using` statements. This means that they will be disposed of when exiting the block, regardless of how it happens (be it through normal control flow or an exception being thrown).

Formerly, the best, cleanest code we were able to write was something like this:

```csharp
{
    using (var fileHandle = File.OpenRead("log.txt"))
    {
        // Do operations with fileHandle
        // Files have to be closed after we are done using them
    }
}
```

In newer versions of .NET, though, we can do the following:

```csharp
{
    using var fileHandle = File.OpenRead("log.txt");
    // Do operations with fileHandle
    // Files have to be closed after we are using them
}
```

This looks closer to regular variable initialization, which allows us to keep the statement more readable, whist preserving the benefits of handling our `IDisposable` objects properly.

# Changes proposed in this pull request

In this pull request, I've aimed to improve code readability by translating `using` statements from the former syntax to the newer syntax in several places throughout the code. This has helped me reduce block nesting levels, which are one of the things that can make it harder to understand what is happening.