### PR TITLE
v9.0.271-pre - General Cleanup

### DIFF
--- a/src/Prism.Avalonia/Navigation/Regions/Behaviors/BindRegionContextToAvaloniaObjectBehavior.cs
+++ b/src/Prism.Avalonia/Navigation/Regions/Behaviors/BindRegionContextToAvaloniaObjectBehavior.cs
@@ -13,7 +13,7 @@ namespace Prism.Navigation.Regions.Behaviors
     public class BindRegionContextToAvaloniaObjectBehavior : IRegionBehavior
     {
     /// <summary>The key of this behavior.</summary>
-    /// <remarks>This SHOULD be ''ContextToAvaloniaObject'.</remarks>
+    /// <remarks>TODO (DS 2024-04-11): This SHOULD be ''ContextToAvaloniaObject'.</remarks>
     public const string BehaviorKey = "ContextToDependencyObject";
 
     /// <summary>Behavior's attached region.</summary>

--- a/src/Prism.Avalonia/Navigation/Regions/Behaviors/BindRegionContextToAvaloniaObjectBehavior.cs
+++ b/src/Prism.Avalonia/Navigation/Regions/Behaviors/BindRegionContextToAvaloniaObjectBehavior.cs
@@ -10,9 +10,10 @@ namespace Prism.Navigation.Regions.Behaviors
     /// Defines a behavior that forwards the <see cref="RegionManager.RegionContextProperty"/>
     /// to the views in the region.
     /// </summary>
-    public class BindRegionContextToDependencyObjectBehavior : IRegionBehavior
-{
+    public class BindRegionContextToAvaloniaObjectBehavior : IRegionBehavior
+    {
     /// <summary>The key of this behavior.</summary>
+    /// <remarks>This SHOULD be ''ContextToAvaloniaObject'.</remarks>
     public const string BehaviorKey = "ContextToDependencyObject";
 
     /// <summary>Behavior's attached region.</summary>

--- a/src/Prism.Avalonia/Navigation/Regions/Behaviors/RegionMemberLifetimeBehavior.cs
+++ b/src/Prism.Avalonia/Navigation/Regions/Behaviors/RegionMemberLifetimeBehavior.cs
@@ -42,7 +42,7 @@ namespace Prism.Navigation.Regions.Behaviors
         /// </summary>
         protected override void OnAttach()
         {
-            Region.ActiveViews.CollectionChanged += sOnActiveViewsChanged;
+            Region.ActiveViews.CollectionChanged += OnActiveViewsChanged;
         }
 
         private void OnActiveViewsChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/Prism.Avalonia/Navigation/Regions/Behaviors/SelectorItemsSourceSyncBehavior.cs
+++ b/src/Prism.Avalonia/Navigation/Regions/Behaviors/SelectorItemsSourceSyncBehavior.cs
@@ -1,4 +1,4 @@
-// TODO: 2022-07-08 - Feature disabled until a workaround can be created
+﻿// TODO: 2022-07-08 - Feature disabled until a workaround can be created
 // Consider using Avalonia.Styling.IStylable or Avalonia.Styling.Selector
 // in place of WPF's `Selector` object or AvaloniaObject.
 // This theory is untested and causes issues on code such as, `hostControl.Items`
@@ -20,7 +20,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using System.Windows.Controls.Primitives;
 
-namespace Prism.Regions.Behaviors
+namespace Prism.Navigation.Regions.Behaviors
 {
     /// <summary>
     /// Defines the attached behavior that keeps the items of the <see cref="Selector"/> host control in synchronization with the <see cref="IRegion"/>.

--- a/src/Prism.Avalonia/Navigation/Regions/Behaviors/SyncRegionContextWithHostBehavior.cs
+++ b/src/Prism.Avalonia/Navigation/Regions/Behaviors/SyncRegionContextWithHostBehavior.cs
@@ -49,6 +49,7 @@ namespace Prism.Navigation.Regions.Behaviors
                 {
                     throw new InvalidOperationException(Resources.HostControlCannotBeSetAfterAttach);
                 }
+
                 hostControl = value;
             }
         }

--- a/src/Prism.Avalonia/Navigation/Regions/RegionManager.cs
+++ b/src/Prism.Avalonia/Navigation/Regions/RegionManager.cs
@@ -371,12 +371,12 @@ namespace Prism.Navigation.Regions
         }
 
         /// <summary>
-        /// This method allows an IRegionManager to locate a specified region and navigate in it to the specified target Uri, passing a navigation callback and an instance of NavigationParameters, which holds a collection of object parameters.
+        /// This method allows an IRegionManager to locate a specified region and navigate in it to the specified target Uri, passing a navigation callback and an instance of <see cref="NavigationParameters"/>, which holds a collection of object parameters.
         /// </summary>
         /// <param name="regionName">The name of the region where the navigation will occur.</param>
         /// <param name="target">A Uri that represents the target where the region will navigate.</param>
         /// <param name="navigationCallback">The navigation callback that will be executed after the navigation is completed.</param>
-        /// <param name="navigationParameters">An instance of NavigationParameters, which holds a collection of object parameters.</param>
+        /// <param name="navigationParameters">An instance of <see cref="NavigationParameters">, which holds a collection of object parameters.</param>
         public void RequestNavigate(string regionName, Uri target, Action<NavigationResult> navigationCallback, INavigationParameters navigationParameters)
         {
             if (navigationCallback == null)

--- a/src/Prism.Avalonia/Navigation/Regions/SelectorRegionAdapter.cs
+++ b/src/Prism.Avalonia/Navigation/Regions/SelectorRegionAdapter.cs
@@ -1,6 +1,6 @@
 ﻿// TODO: Feature currently disabled
 /*
-using Prism.Regions.Behaviors;
+using Prism.Navigation.Regions.Behaviors;
 using System;
 using Avalonia.Controls.Primitives;
 using Avalonia.Styling;

--- a/src/Prism.Avalonia/Properties/AssemblyInfo.cs
+++ b/src/Prism.Avalonia/Properties/AssemblyInfo.cs
@@ -5,15 +5,8 @@ using Avalonia.Metadata;
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(true)]
 
-// -----  Legacy -----
-[assembly: XmlnsDefinition("http://www.codeplex.com/prism", "Prism.Regions")]
-[assembly: XmlnsDefinition("http://www.codeplex.com/prism", "Prism.Regions.Behaviors")]
-[assembly: XmlnsDefinition("http://www.codeplex.com/prism", "Prism.Mvvm")]
-[assembly: XmlnsDefinition("http://www.codeplex.com/prism", "Prism.Interactivity")]
-// -----  Legacy -----
-
-[assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Regions")]
-[assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Regions.Behaviors")]
+[assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Navigation.Regions")]
+[assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Navigation.Regions.Behaviors")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Mvvm")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Interactivity")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Dialogs")]

--- a/tests/Avalonia/Prism.Avalonia.Tests/Mocks/MockHostAwareRegionBehavior.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Mocks/MockHostAwareRegionBehavior.cs
@@ -1,6 +1,5 @@
-using Avalonia;
+﻿using Avalonia;
 using Prism.Navigation.Regions.Behaviors;
-using Prism.Regions;
 
 namespace Prism.Avalonia.Tests.Mocks
 {

--- a/tests/Avalonia/Prism.Avalonia.Tests/Mocks/MockSortableViews.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Mocks/MockSortableViews.cs
@@ -1,6 +1,4 @@
-using Prism.Regions;
-
-namespace Prism.Avalonia.Tests.Mocks
+﻿namespace Prism.Avalonia.Tests.Mocks
 {
     [ViewSortHint("01")]
     internal class MockSortableView1

--- a/tests/Avalonia/Prism.Avalonia.Tests/PrismApplicationBaseFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/PrismApplicationBaseFixture.cs
@@ -166,7 +166,7 @@ namespace Prism.Avalonia.Tests
         }
 
         [Fact]
-        public void ConfigureDefaultRegionBehaviorsShouldBindRegionContextToDependencyObjectBehavior()
+        public void ConfigureDefaultRegionBehaviorsShouldBindRegionContextToAvaloniaObjectBehavior()
         {
             Assert.True(application.DefaultRegionBehaviorTypes.ContainsKey(BindRegionContextToAvaloniaObjectBehavior.BehaviorKey));
         }

--- a/tests/Avalonia/Prism.Avalonia.Tests/PrismBootstrapperBaseFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/PrismBootstrapperBaseFixture.cs
@@ -161,7 +161,7 @@ namespace Prism
         }
 
         [Fact]
-        public void ConfigureDefaultRegionBehaviorsShouldBindRegionContextToDependencyObjectBehavior()
+        public void ConfigureDefaultRegionBehaviorsShouldBindRegionContextToAvaloniaObjectBehavior()
         {
             Assert.True(bootstrapper.DefaultRegionBehaviorTypes.ContainsKey(BindRegionContextToAvaloniaObjectBehavior.BehaviorKey));
         }

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/AllActiveRegionFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/AllActiveRegionFixture.cs
@@ -1,5 +1,4 @@
-using Prism.Regions;
-using Xunit;
+﻿using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions
 {

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/AutoPopulateRegionBehaviorFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/AutoPopulateRegionBehaviorFixture.cs
@@ -1,5 +1,5 @@
-using Prism.Avalonia.Tests.Mocks;
-using Prism.Regions.Behaviors;
+﻿using Prism.Avalonia.Tests.Mocks;
+using Prism.Navigation.Regions.Behaviors;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions.Behaviors

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/BindRegionContextToAvaloniaObjectBehaviorFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/BindRegionContextToAvaloniaObjectBehaviorFixture.cs
@@ -1,5 +1,5 @@
-using Prism.Avalonia.Tests.Mocks;
-using Prism.Regions.Behaviors;
+﻿using Prism.Avalonia.Tests.Mocks;
+using Prism.Navigation.Regions.Behaviors;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions.Behaviors

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionActiveAwareBehaviorFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionActiveAwareBehaviorFixture.cs
@@ -1,8 +1,8 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Moq;
 using Prism.Avalonia.Tests.Mocks;
-using Prism.Regions.Behaviors;
+using Prism.Navigation.Regions.Behaviors;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions.Behaviors

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionManagerRegistrationBehaviorFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionManagerRegistrationBehaviorFixture.cs
@@ -1,7 +1,7 @@
-using System.Collections;
+﻿using System.Collections;
 using Avalonia.Controls;
 using Prism.Avalonia.Tests.Mocks;
-using Prism.Regions.Behaviors;
+using Prism.Navigation.Regions.Behaviors;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions.Behaviors

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionManagerRegistrationBehaviorFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionManagerRegistrationBehaviorFixture.cs
@@ -246,8 +246,8 @@ namespace Prism.Avalonia.Tests.Regions.Behaviors
                 throw new NotImplementedException();
             }
 
-            public IRegionManager RegisterViewWithRegion(string regionName, Func<object> getContentDelegate)
-            {
+            public IRegionManager RegisterViewWithRegion(string regionName, Func<IContainerProvider, object> getContentDelegate)
+            { 
                 throw new NotImplementedException();
             }
 
@@ -271,22 +271,22 @@ namespace Prism.Avalonia.Tests.Regions.Behaviors
                 throw new NotImplementedException();
             }
 
-            public void RequestNavigate(string regionName, Uri target, Action<NavigationResult> navigationCallback, NavigationParameters navigationParameters)
+            public void RequestNavigate(string regionName, Uri target, Action<NavigationResult> navigationCallback, INavigationParameters navigationParameters)
             {
                 throw new NotImplementedException();
             }
 
-            public void RequestNavigate(string regionName, string target, Action<NavigationResult> navigationCallback, NavigationParameters navigationParameters)
+            public void RequestNavigate(string regionName, string target, Action<NavigationResult> navigationCallback, INavigationParameters navigationParameters)
             {
                 throw new NotImplementedException();
             }
 
-            public void RequestNavigate(string regionName, Uri target, NavigationParameters navigationParameters)
+            public void RequestNavigate(string regionName, Uri target, INavigationParameters navigationParameters)
             {
                 throw new NotImplementedException();
             }
 
-            public void RequestNavigate(string regionName, string target, NavigationParameters navigationParameters)
+            public void RequestNavigate(string regionName, string target, INavigationParameters navigationParameters)
             {
                 throw new NotImplementedException();
             }

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionMemberLifetimeBehaviorFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionMemberLifetimeBehaviorFixture.cs
@@ -1,7 +1,7 @@
-using Moq;
+﻿using Moq;
 using Prism.Avalonia.Tests.Mocks;
 using Prism.Navigation.Regions.Behaviors;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions.Behaviors

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionMemberLifetimeBehaviorFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/RegionMemberLifetimeBehaviorFixture.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using Prism.Avalonia.Tests.Mocks;
 using Prism.Navigation.Regions.Behaviors;
-using Prism.Navigation.Regions;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions.Behaviors
@@ -18,10 +17,10 @@ namespace Prism.Avalonia.Tests.Regions.Behaviors
 
         protected virtual void Arrange()
         {
-            this.Region = new Region();
-            this.Behavior = new RegionMemberLifetimeBehavior();
-            this.Behavior.Region = this.Region;
-            this.Behavior.Attach();
+            Region = new Region();
+            Behavior = new RegionMemberLifetimeBehavior();
+            Behavior.Region = Region;
+            Behavior.Attach();
         }
 
         [Fact]
@@ -244,20 +243,17 @@ namespace Prism.Avalonia.Tests.Regions.Behaviors
         public class RegionMemberKeptAlive
         {
         }
-
-
     }
-
 
     public class RegionMemberLifetimeBehaviorAgainstSingleActiveRegionFixture
                 : RegionMemberLifetimeBehaviorFixture
     {
         protected override void Arrange()
         {
-            this.Region = new SingleActiveRegion();
-            this.Behavior = new RegionMemberLifetimeBehavior();
-            this.Behavior.Region = this.Region;
-            this.Behavior.Attach();
+            Region = new SingleActiveRegion();
+            Behavior = new RegionMemberLifetimeBehavior();
+            Behavior.Region = Region;
+            Behavior.Attach();
         }
     }
 }

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/SelectorItemsSourceSyncRegionBehaviorFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/Behaviors/SelectorItemsSourceSyncRegionBehaviorFixture.cs
@@ -1,4 +1,4 @@
-// This feature is currently disabled
+﻿// This feature is currently disabled
 // See, Prism.Avalonia.Regions.Behaviors.SelectorItemsSourceSyncBehavior.cs for more info.
 /*
 using System;
@@ -7,8 +7,8 @@ using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
-using Prism.Regions;
-using Prism.Regions.Behaviors;
+using Prism.Navigation.Regions;
+using Prism.Navigation.Regions.Behaviors;
 using Prism.Avalonia.Tests.Mocks;
 using Xunit;
 

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/ItemsControlRegionAdapterFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/ItemsControlRegionAdapterFixture.cs
@@ -1,4 +1,4 @@
-// TODO: 2022-07-12
+﻿// TODO: 2022-07-12
 // REF: https://github.com/AvaloniaUI/Avalonia/issues/7553
 // Cannot perform the following. Check out, ContentControlRegionAdapterFixture.cs
 // However, ItemsControl.Items is `IEnumerable` and doesn't play nicely.
@@ -10,7 +10,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using Prism.Avalonia.Tests.Mocks;
 using Avalonia.Controls;
 using Avalonia.Data;

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/NavigationContextFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/NavigationContextFixture.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Linq;
-using Moq;
-using Prism.Regions;
+﻿using Moq;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/NavigationParametersFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/NavigationParametersFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/RegionAdapterMappingsFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/RegionAdapterMappingsFixture.cs
@@ -1,4 +1,4 @@
-using Prism.Regions;
+﻿using Prism.Navigation.Regions;
 using Prism.Avalonia.Tests.Mocks;
 using Avalonia.Controls;
 using Moq;
@@ -49,7 +49,7 @@ namespace Prism.Avalonia.Tests.Regions
                 containerMock.Setup(c => c.Resolve(typeof(MockRegionAdapter)))
                              .Returns(regionAdapter);
                 ContainerLocator.ResetContainer();
-                ContainerLocator.SetContainerExtension(() => containerMock.Object);
+                ContainerLocator.SetContainerExtension(containerMock.Object);
 
                 regionAdapterMappings.RegisterMapping<ItemsControl, MockRegionAdapter>();
 

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/RegionViewRegistryFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/RegionViewRegistryFixture.cs
@@ -4,7 +4,7 @@ using Moq;
 using Prism.Avalonia.Tests.Mocks.Views;
 using Prism.Avalonia.Tests.Mvvm;
 using Prism.Ioc;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions
@@ -82,7 +82,7 @@ namespace Prism.Avalonia.Tests.Regions
             Assert.NotNull(listener.onViewRegisteredArguments);
             Assert.NotNull(listener.onViewRegisteredArguments.GetView);
 
-            var result = listener.onViewRegisteredArguments.GetView();
+            var result = listener.onViewRegisteredArguments.GetView(containerMock.Object);
             Assert.NotNull(result);
             Assert.IsType<MockContentObject>(result);
         }

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/SelectorRegionAdapterFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/SelectorRegionAdapterFixture.cs
@@ -1,10 +1,10 @@
-// TODO: 2022-07-13
+﻿// TODO: 2022-07-13
 // Feature, SelectorRegionAdapter, is currently disabled.
 /*
 using System;
 using Avalonia.Controls;
-using Prism.Regions;
-using Prism.Regions.Behaviors;
+using Prism.Navigation.Regions;
+using Prism.Navigation.Regions.Behaviors;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions

--- a/tests/Avalonia/Prism.Avalonia.Tests/Regions/SingleActiveRegionFixture.cs
+++ b/tests/Avalonia/Prism.Avalonia.Tests/Regions/SingleActiveRegionFixture.cs
@@ -1,4 +1,4 @@
-using Prism.Regions;
+﻿using Prism.Navigation.Regions;
 using Xunit;
 
 namespace Prism.Avalonia.Tests.Regions


### PR DESCRIPTION
Generic repo cleanup from Prism.Navigation.Region updates

* `Prism.Region` -> `Prism.Navigation.Region`
* Documentation of `DependencyObject` -> `AvaloniaObject`