### PR TITLE
Prism v9.0.271-pre - Update End-to-End Samples

### DIFF
--- a/e2e/DummyModule1/DummyModule1.cs
+++ b/e2e/DummyModule1/DummyModule1.cs
@@ -9,7 +9,7 @@ using Prism.Events;
 using Prism.Ioc;
 ////using Prism.Logging;
 using Prism.Modularity;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 
 namespace DummyModule
 {

--- a/e2e/DummyModule1/Views/DummyModuleView.axaml
+++ b/e2e/DummyModule1/Views/DummyModuleView.axaml
@@ -1,6 +1,6 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:prism="clr-namespace:Prism.Regions.Behaviors;assembly=Prism.Avalonia"
+             xmlns:prism="clr-namespace:Prism.Navigation.Regions.Behaviors;assembly=Prism.Avalonia"
              x:Class="DummyModule.View.DummyModuleView">
   <StackPanel Orientation="Horizontal">
     <TextBox Text="DummyModule1 Region View"

--- a/e2e/DummyModule2/DumyModule2.cs
+++ b/e2e/DummyModule2/DumyModule2.cs
@@ -2,7 +2,7 @@
 using ModulesSample.Infrastructure;
 using Prism.Ioc;
 using Prism.Modularity;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 
 namespace DummyModule2
 {

--- a/e2e/DummyModule2/Views/DummyModuleView2.axaml
+++ b/e2e/DummyModule2/Views/DummyModuleView2.axaml
@@ -1,7 +1,7 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:prism="clr-namespace:Prism.Regions.Behaviors;assembly=Prism.Avalonia"
-             xmlns:prismRegions="clr-namespace:Prism.Regions;assembly=Prism.Avalonia"
+             xmlns:prism="clr-namespace:Prism.Navigation.Regions.Behaviors;assembly=Prism.Avalonia"
+             xmlns:prismRegions="clr-namespace:Prism.Navigation.Regions;assembly=Prism.Avalonia"
              x:Class="DummyModule2.View.DummyModuleView2">
   <Grid>
     <TextBox Name="RegionViewTextBox"

--- a/e2e/DummyModule2/Views/DummyModuleView2.axaml.cs
+++ b/e2e/DummyModule2/Views/DummyModuleView2.axaml.cs
@@ -3,7 +3,7 @@ using Avalonia.Threading;
 using ModulesSample.Infrastructure;
 using Prism.Avalonia.Infrastructure.Events;
 using Prism.Events;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 
 namespace DummyModule2.View
 {

--- a/e2e/ModulesSample/MainWindow.axaml
+++ b/e2e/ModulesSample/MainWindow.axaml
@@ -1,6 +1,6 @@
 ﻿<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:prismRegions="clr-namespace:Prism.Regions;assembly=Prism.Avalonia"
+        xmlns:prismRegions="clr-namespace:Prism.Navigation.Regions;assembly=Prism.Avalonia"
         MinWidth="500" MinHeight="300"
         x:Class="ModulesSample.MainWindow">
   <StackPanel Orientation="Vertical">

--- a/e2e/SampleDialogApp/App.axaml.cs
+++ b/e2e/SampleDialogApp/App.axaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Avalonia;
 using Avalonia.Markup.Xaml;
 using Prism.DryIoc;
@@ -27,5 +27,6 @@ public partial class App : PrismApplication
         containerRegistry.Register<MainWindow>();
         containerRegistry.RegisterDialog<MessageBoxView, MessageBoxViewModel>();
         containerRegistry.RegisterDialog<DialogView, DialogViewModel>();
+        containerRegistry.RegisterDialogWindow<CustomDialogWindow>(nameof(CustomDialogWindow));
     }
 }

--- a/e2e/SampleDialogApp/ViewModels/DialogViewModel.cs
+++ b/e2e/SampleDialogApp/ViewModels/DialogViewModel.cs
@@ -27,19 +27,24 @@ public class DialogViewModel : BindableBase, IDialogAware
 
     public string Title { get => _title; set => SetProperty(ref _title, value); }
 
-    /// <summary>Gets or sets the optional parent window of this Dialog pop-up.</summary>
-    public Window? ParentWindow { get => _parentWindow; set => SetProperty(ref _parentWindow, value); }
+    /////// <summary>Gets or sets the optional parent window of this Dialog pop-up.</summary>
+    ////public Window? ParentWindow { get => _parentWindow; set => SetProperty(ref _parentWindow, value); }
 
     public DelegateCommand CmdModalDialog => new(() =>
     {
         var title = "MessageBox Title Here";
-        var message = "Hello, I am a modal MessageBox window.\n\n" +
-                      $"I {(ParentWindow == null ? "dont" : "do")} have a parent.";
+        var message = "Hello, I am a modal MessageBox window.";
 
+        // v9.0.271
         _dialogService.ShowDialog(
-            ParentWindow,
             nameof(MessageBoxView),
             new DialogParameters($"title={title}&message={message}"));
+
+        // 8.1.97
+        ////_dialogService.ShowDialog(
+        ////    ParentWindow,
+        ////    nameof(MessageBoxView),
+        ////    new DialogParameters($"title={title}&message={message}"));
     });
 
     public DelegateCommand<string> CmdResult => new DelegateCommand<string>((param) =>
@@ -57,12 +62,14 @@ public class DialogViewModel : BindableBase, IDialogAware
         if (int.TryParse(param, out int intResult))
             result = (ButtonResult)intResult;
 
-        RaiseRequestClose(new DialogResult(result));
+        // NEW
+        RequestClose.Invoke(result);
+
+        // OLD
+        ////RaiseRequestClose(new DialogResult(result));
     });
 
     public string CustomMessage { get => _customMessage; set => SetProperty(ref _customMessage, value); }
-
-    public event Action<IDialogResult>? RequestClose;
 
     public virtual bool CanCloseDialog()
     {
@@ -80,8 +87,8 @@ public class DialogViewModel : BindableBase, IDialogAware
         CustomMessage = parameters.GetValue<string>("message");
     }
 
-    public virtual void RaiseRequestClose(IDialogResult dialogResult)
-    {
-        RequestClose?.Invoke(dialogResult);
-    }
+    ////public virtual void RaiseRequestClose(IDialogResult dialogResult)
+    ////{
+    ////    RequestClose?.Invoke(dialogResult);
+    ////}
 }

--- a/e2e/SampleDialogApp/ViewModels/DialogViewModel.cs
+++ b/e2e/SampleDialogApp/ViewModels/DialogViewModel.cs
@@ -56,6 +56,27 @@ public class DialogViewModel : BindableBase, IDialogAware
         ////    new DialogParameters($"title={title}&message={message}"));
     });
 
+    public DelegateCommand CmdCustomDialogWindow => new(() =>
+    {
+        // This passes the "title" to the Custom window's Title
+        // that is based off of it's inner 'MessageBoxView' UserControl.
+        var title = "Custom Title";
+        var message = "Hello, I custom dialog window running inside of Prism.Avalonia!";
+
+        // NOTE:
+        //  When setting, 'KnownDialogParameters.WindowName' the DialogService
+        //  uses SampleDialogApp's CustomDialogWindow instead of
+        //  Prism.Avalonia's default DialogWindow.
+        _dialogService.ShowDialog(
+            name: nameof(MessageBoxView),
+            new DialogParameters
+            {
+                { "title", title },
+                { "message", message },
+                { KnownDialogParameters.WindowName, nameof(CustomDialogWindow) }
+            });
+    });
+
     public DelegateCommand<string> CmdResult => new DelegateCommand<string>((param) =>
     {
         // None = 0, OK = 1, Cancel = 2, Abort = 3, Retry = 4, Ignore = 5, Yes = 6, No = 7

--- a/e2e/SampleDialogApp/ViewModels/DialogViewModel.cs
+++ b/e2e/SampleDialogApp/ViewModels/DialogViewModel.cs
@@ -12,6 +12,8 @@ public class DialogViewModel : BindableBase, IDialogAware
     private readonly IDialogService _dialogService;
     private string _customMessage = string.Empty;
     private string _title = "Notification";
+
+    /// <summary>Custom Prism.Avalonia feature.</summary>
     private Window? _parentWindow = null;
 
     public DialogViewModel(IDialogService dialogService)
@@ -23,24 +25,31 @@ public class DialogViewModel : BindableBase, IDialogAware
         Title = "I'm a Sample Dialog!";
     }
 
+    // New: v9.0.271-pre
     public DialogCloseListener RequestClose { get; }
 
     public string Title { get => _title; set => SetProperty(ref _title, value); }
 
-    /////// <summary>Gets or sets the optional parent window of this Dialog pop-up.</summary>
-    ////public Window? ParentWindow { get => _parentWindow; set => SetProperty(ref _parentWindow, value); }
+    // Custom Prism.Avalonia feature
+    /// <summary>Gets or sets the optional parent window of this Dialog pop-up.</summary>
+    public Window? ParentWindow { get => _parentWindow; set => SetProperty(ref _parentWindow, value); }
 
     public DelegateCommand CmdModalDialog => new(() =>
     {
         var title = "MessageBox Title Here";
-        var message = "Hello, I am a modal MessageBox window.";
+        var message = "Hello, I am a modal MessageBox called via the ViewModel.\n\n" +
+                      "My parent window is the DialogView's window.";
 
         // v9.0.271
         _dialogService.ShowDialog(
-            nameof(MessageBoxView),
-            new DialogParameters($"title={title}&message={message}"));
+            name: nameof(MessageBoxView),
+            parameters: new DialogParameters($"title={title}&message={message}")
+            {
+                // This informs the DialogService to use this window for MessageBoxView's parent.
+                { KnownDialogParameters.ParentWindow , ParentWindow },
+            });
 
-        // 8.1.97
+        // v8.1.97
         ////_dialogService.ShowDialog(
         ////    ParentWindow,
         ////    nameof(MessageBoxView),
@@ -49,23 +58,16 @@ public class DialogViewModel : BindableBase, IDialogAware
 
     public DelegateCommand<string> CmdResult => new DelegateCommand<string>((param) =>
     {
-        // None = 0
-        // OK = 1
-        // Cancel = 2
-        // Abort = 3
-        // Retry = 4
-        // Ignore = 5
-        // Yes = 6
-        // No = 7
+        // None = 0, OK = 1, Cancel = 2, Abort = 3, Retry = 4, Ignore = 5, Yes = 6, No = 7
         ButtonResult result = ButtonResult.None;
 
         if (int.TryParse(param, out int intResult))
             result = (ButtonResult)intResult;
 
-        // NEW
+        // NEW: 9.0.271-pre
         RequestClose.Invoke(result);
 
-        // OLD
+        // OLD: v8.1.97
         ////RaiseRequestClose(new DialogResult(result));
     });
 
@@ -87,6 +89,7 @@ public class DialogViewModel : BindableBase, IDialogAware
         CustomMessage = parameters.GetValue<string>("message");
     }
 
+    // OLD: v8.1.97
     ////public virtual void RaiseRequestClose(IDialogResult dialogResult)
     ////{
     ////    RequestClose?.Invoke(dialogResult);

--- a/e2e/SampleDialogApp/ViewModels/MainWindowViewModel.cs
+++ b/e2e/SampleDialogApp/ViewModels/MainWindowViewModel.cs
@@ -22,7 +22,7 @@ public class MainWindowViewModel : ViewModelBase
         var message = "Hello, I am a simple MessageBox modal window with an OK button.\n\n" +
                       "When too much text is added, a scrollbar will appear.";
 
-        _dialogService.ShowDialog(nameof(MessageBoxView), new DialogParameters($"title={title}&message={message}"), r => { });
+        _dialogService.ShowDialog(nameof(MessageBoxView), new DialogParameters($"title={title}&message={message}"));
     });
 
     public DelegateCommand CmdShowDialog => new DelegateCommand(() =>

--- a/e2e/SampleDialogApp/ViewModels/MessageBoxViewModel.cs
+++ b/e2e/SampleDialogApp/ViewModels/MessageBoxViewModel.cs
@@ -27,7 +27,11 @@ public class MessageBoxViewModel : BindableBase, IDialogAware
         MaxWidth = 600;
     }
 
-    public event Action<IDialogResult>? RequestClose;
+    // v9.0.271-pre
+    public DialogCloseListener RequestClose { get; }
+
+    // v8.1.97
+    // public event Action<IDialogResult>? RequestClose;
 
     public string Title { get => _title; set => SetProperty(ref _title, value); }
 
@@ -37,29 +41,23 @@ public class MessageBoxViewModel : BindableBase, IDialogAware
 
     public DelegateCommand<string> CmdResult => new DelegateCommand<string>((param) =>
     {
-        // None = 0
-        // OK = 1
-        // Cancel = 2
-        // Abort = 3
-        // Retry = 4
-        // Ignore = 5
-        // Yes = 6
-        // No = 7
+        // None = 0, OK = 1, Cancel = 2, Abort = 3, Retry = 4, Ignore = 5, Yes = 6, No = 7
         ButtonResult result = ButtonResult.None;
 
         if (int.TryParse(param, out int intResult))
             result = (ButtonResult)intResult;
 
-        RaiseRequestClose(new DialogResult(result));
+        // v9.0.271-pre
+        RequestClose.Invoke(result);
+
+        // v8.1.97
+        // RaiseRequestClose(new DialogResult(result));
     });
 
     public string CustomMessage { get => _customMessage; set => SetProperty(ref _customMessage, value); }
 
-    public virtual bool CanCloseDialog()
-    {
-        // Allow the dialog to close
-        return true;
-    }
+    /// <summary>Allow the dialog to close</summary>
+    public virtual bool CanCloseDialog() => true;
 
     public virtual void OnDialogClosed()
     {
@@ -75,8 +73,9 @@ public class MessageBoxViewModel : BindableBase, IDialogAware
         CustomMessage = parameters.GetValue<string>("message");
     }
 
-    public virtual void RaiseRequestClose(IDialogResult dialogResult)
-    {
-        RequestClose?.Invoke(dialogResult);
-    }
+    // v8.1.97
+    ////public virtual void RaiseRequestClose(IDialogResult dialogResult)
+    ////{
+    ////    RequestClose?.Invoke(dialogResult);
+    ////}
 }

--- a/e2e/SampleDialogApp/ViewModels/ViewModelBase.cs
+++ b/e2e/SampleDialogApp/ViewModels/ViewModelBase.cs
@@ -1,5 +1,5 @@
 ﻿using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 
 namespace SampleDialogApp.ViewModels;
 

--- a/e2e/SampleDialogApp/Views/CustomDialogWindow.axaml
+++ b/e2e/SampleDialogApp/Views/CustomDialogWindow.axaml
@@ -1,0 +1,20 @@
+﻿<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200"
+        x:Class="SampleDialogApp.Views.CustomDialogWindow"
+        Title="{Binding Title}"
+        Background="BlueViolet"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <Style Selector="Window">
+      <Setter Property="SizeToContent" Value="WidthAndHeight" />
+    </Style>
+  </Window.Styles>
+  <Panel>
+    <StackPanel>
+      <Label Content="This content gets overridden!" />
+    </StackPanel>
+  </Panel>
+</Window>

--- a/e2e/SampleDialogApp/Views/CustomDialogWindow.axaml.cs
+++ b/e2e/SampleDialogApp/Views/CustomDialogWindow.axaml.cs
@@ -1,0 +1,26 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Prism.Dialogs;
+
+namespace SampleDialogApp.Views;
+
+/// <summary>Custom dialog window host.</summary>
+public partial class CustomDialogWindow : Window, IDialogWindow
+{
+    public CustomDialogWindow()
+    {
+        InitializeComponent();
+#if DEBUG
+        this.AttachDevTools();
+#endif
+    }
+
+    /// <summary>The <see cref="IDialogResult"/> of the dialog.</summary>
+    public IDialogResult Result { get; set; }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/e2e/SampleDialogApp/Views/DialogView.axaml
+++ b/e2e/SampleDialogApp/Views/DialogView.axaml
@@ -1,4 +1,4 @@
-<UserControl xmlns="https://github.com/avaloniaui"
+﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -14,6 +14,10 @@
     <StackPanel Orientation="Horizontal" Spacing="5">
       <Button Content="Modal from .AXAML.CS" Click="BtnShowModal_Click" />
       <Button Content="Modal from MVVM" Command="{Binding CmdModalDialog}" />
+    </StackPanel>
+
+    <StackPanel Orientation="Horizontal" Spacing="5">
+      <Button Content="Custom Dialog Window" Command="{Binding CmdCustomDialogWindow}" />
     </StackPanel>
 
     <StackPanel Orientation="Horizontal">

--- a/e2e/SampleDialogApp/Views/DialogView.axaml.cs
+++ b/e2e/SampleDialogApp/Views/DialogView.axaml.cs
@@ -18,14 +18,15 @@ public partial class DialogView : UserControl
     {
         base.OnInitialized();
 
-        // Pass the parent window to the ViewModel
-        // given that the ViewModel has been binded to this view
-        DialogViewModel? viewModel = this.DataContext as DialogViewModel;
-        if (this.Parent is Window parent &&
-            viewModel is not null)
-        {
-            viewModel.ParentWindow = parent;
-        }
+        // v8.1.97
+        ////// Pass the parent window to the ViewModel
+        ////// given that the ViewModel has been binded to this view
+        ////DialogViewModel? viewModel = this.DataContext as DialogViewModel;
+        ////if (this.Parent is Window parent &&
+        ////    viewModel is not null)
+        ////{
+        ////    viewModel.ParentWindow = parent;
+        ////}
     }
 
     private void InitializeComponent()
@@ -42,9 +43,15 @@ public partial class DialogView : UserControl
                       "I've been called by the `.axaml.cs` UserControl.";
 
         dialogSvc.ShowDialog(
-            this.Parent as Window,
             nameof(MessageBoxView),
             new DialogParameters($"title={title}&message={message}"),
             r => { });
+
+        // v8.1.97
+        ////dialogSvc.ShowDialog(
+        ////    this.Parent as Window,
+        ////    nameof(MessageBoxView),
+        ////    new DialogParameters($"title={title}&message={message}"),
+        ////    r => { });
     }
 }

--- a/e2e/SampleDialogApp/Views/DialogView.axaml.cs
+++ b/e2e/SampleDialogApp/Views/DialogView.axaml.cs
@@ -18,15 +18,14 @@ public partial class DialogView : UserControl
     {
         base.OnInitialized();
 
-        // v8.1.97
-        ////// Pass the parent window to the ViewModel
-        ////// given that the ViewModel has been binded to this view
-        ////DialogViewModel? viewModel = this.DataContext as DialogViewModel;
-        ////if (this.Parent is Window parent &&
-        ////    viewModel is not null)
-        ////{
-        ////    viewModel.ParentWindow = parent;
-        ////}
+        // Pass the parent window to the ViewModel
+        // given that the ViewModel has been binded to this view
+        DialogViewModel? viewModel = this.DataContext as DialogViewModel;
+        if (this.Parent is Window parent &&
+            viewModel is not null)
+        {
+            viewModel.ParentWindow = parent;
+        }
     }
 
     private void InitializeComponent()
@@ -39,13 +38,19 @@ public partial class DialogView : UserControl
         var dialogSvc = ContainerLocator.Current.Resolve<IDialogService>();
 
         var title = "MessageBox Title Here";
-        var message = "Hello, I am a simple modal MessageBox with an OK button.\n\n" +
-                      "I've been called by the `.axaml.cs` UserControl.";
+        var message = "Hello, I am a modal MessageBox called via the `.axaml.cs` UserControl.\n\n" +
+                      "My parent window is the DialogView's window.";
+
+        // Really you could just use 'this.Parent'. This ensures that our parent is a window and not another UserControl.
+        var parentWindow = this.Parent is Window parent ? parent : null;
 
         dialogSvc.ShowDialog(
             nameof(MessageBoxView),
-            new DialogParameters($"title={title}&message={message}"),
-            r => { });
+            new DialogParameters($"title={title}&message={message}")
+            {
+                // This informs the DialogService to use this window for MessageBoxView's parent.
+                { KnownDialogParameters.ParentWindow, this.Parent },
+            });
 
         // v8.1.97
         ////dialogSvc.ShowDialog(

--- a/e2e/SampleDialogApp/Views/MainWindow.axaml
+++ b/e2e/SampleDialogApp/Views/MainWindow.axaml
@@ -1,4 +1,4 @@
-<Window x:Class="SampleDialogApp.Views.MainWindow"
+﻿<Window x:Class="SampleDialogApp.Views.MainWindow"
         xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/e2e/SampleMvvmApp/App.axaml.cs
+++ b/e2e/SampleMvvmApp/App.axaml.cs
@@ -5,7 +5,7 @@ using Avalonia.Markup.Xaml;
 using Prism.DryIoc;
 using Prism.Ioc;
 using Prism.Modularity;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using SampleMvvmApp.Services;
 using SampleMvvmApp.ViewModels;
 using SampleMvvmApp.Views;

--- a/e2e/SampleMvvmApp/RegionAdapters/ItemsControlRegionAdapter.cs
+++ b/e2e/SampleMvvmApp/RegionAdapters/ItemsControlRegionAdapter.cs
@@ -70,6 +70,7 @@ namespace SampleMvvmApp.RegionAdapters
                 {
                     items.Add(enumerator.Current);
                 }
+
                 regionTarget.ItemsSource = items;
             };
         }

--- a/e2e/SampleMvvmApp/RegionAdapters/ItemsControlRegionAdapter.cs
+++ b/e2e/SampleMvvmApp/RegionAdapters/ItemsControlRegionAdapter.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Controls;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 
 namespace SampleMvvmApp.RegionAdapters
 {

--- a/e2e/SampleMvvmApp/ViewModels/MainWindowViewModel.cs
+++ b/e2e/SampleMvvmApp/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Prism.Regions;
+﻿using Prism.Navigation.Regions;
 
 namespace SampleMvvmApp.ViewModels
 {

--- a/e2e/SampleMvvmApp/ViewModels/SettingsViewModel.cs
+++ b/e2e/SampleMvvmApp/ViewModels/SettingsViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using SampleMvvmApp.Views;
 using Prism.Commands;
 using Prism.Navigation.Regions;
+using Prism.Navigation;
 
 namespace SampleMvvmApp.ViewModels
 {
@@ -14,11 +15,13 @@ namespace SampleMvvmApp.ViewModels
             Title = "Settings";
         }
 
-        public DelegateCommand CmdNavigateToChild => new DelegateCommand(() =>
+        public DelegateCommand CmdNavigateToChild => new(() =>
         {
-            var navParams = new NavigationParameters();
-            navParams.Add("key1", "Some text");
-            navParams.Add("key2", 999);
+            var navParams = new NavigationParameters
+            {
+                { "key1", "Some text" },
+                { "key2", 999 }
+            };
 
             _regionManager.RequestNavigate(
                 RegionNames.ContentRegion,

--- a/e2e/SampleMvvmApp/ViewModels/SettingsViewModel.cs
+++ b/e2e/SampleMvvmApp/ViewModels/SettingsViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using SampleMvvmApp.Views;
 using Prism.Commands;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 
 namespace SampleMvvmApp.ViewModels
 {

--- a/e2e/SampleMvvmApp/ViewModels/SidebarViewModel.cs
+++ b/e2e/SampleMvvmApp/ViewModels/SidebarViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using SampleMvvmApp.Views;
 using Prism.Commands;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 
 namespace SampleMvvmApp.ViewModels
 {

--- a/e2e/SampleMvvmApp/ViewModels/SubSettingsViewModel.cs
+++ b/e2e/SampleMvvmApp/ViewModels/SubSettingsViewModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using SampleMvvmApp.Views;
 using Prism.Commands;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 
 namespace SampleMvvmApp.ViewModels
 {

--- a/e2e/SampleMvvmApp/ViewModels/ViewModelBase.cs
+++ b/e2e/SampleMvvmApp/ViewModels/ViewModelBase.cs
@@ -2,7 +2,7 @@
 using System.Linq.Expressions;
 using Prism.Commands;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 
 namespace SampleMvvmApp.ViewModels
 {

--- a/e2e/ViewDiscovery/Views/MainWindow.axaml.cs
+++ b/e2e/ViewDiscovery/Views/MainWindow.axaml.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 
 namespace ViewDiscovery.Views
 {

--- a/src/Prism.Avalonia/Dialogs/DialogService.cs
+++ b/src/Prism.Avalonia/Dialogs/DialogService.cs
@@ -25,18 +25,19 @@ namespace Prism.Dialogs
             parameters ??= new DialogParameters();
             var isModal = parameters.TryGetValue<bool>(KnownDialogParameters.ShowNonModal, out var show) ? !show : true;
             var windowName = parameters.TryGetValue<string>(KnownDialogParameters.WindowName, out var wName) ? wName : null;
+            var owner = parameters.TryGetValue<Window>(KnownDialogParameters.ParentWindow, out var hWnd) ? hWnd : null;
 
             IDialogWindow dialogWindow = CreateDialogWindow(windowName);
             ConfigureDialogWindowEvents(dialogWindow, callback);
             ConfigureDialogWindowContent(name, dialogWindow, parameters);
 
-            ShowDialogWindow(dialogWindow, isModal);
+            ShowDialogWindow(dialogWindow, isModal, owner);
         }
 
         /// <summary>Shows the dialog window.</summary>
         /// <param name="dialogWindow">The dialog window to show.</param>
         /// <param name="isModal">If true; dialog is shown as a modal</param>
-        /// <param name="owner">Optional host window of the dialog.</param>
+        /// <param name="owner">Optional host window of the dialog. Use-case, Dialog calling a dialog.</param>
         protected virtual void ShowDialogWindow(IDialogWindow dialogWindow, bool isModal, Window owner = null)
         {
             if (isModal &&

--- a/src/Prism.Avalonia/Dialogs/IDialogServiceCompatExtensions.cs
+++ b/src/Prism.Avalonia/Dialogs/IDialogServiceCompatExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Avalonia.Controls;
 
 namespace Prism.Dialogs
 {
@@ -48,6 +49,17 @@ namespace Prism.Dialogs
             var parameters = EnsureShowNonModalParameter(null);
             dialogService.Show(name, parameters, callback);
         }
+
+        ////public static void ShowDialog(this IDialogService dialogService, Window owner, string name, IDialogParameters parameters, DialogCallback callback)
+        ////{
+        ////
+        ////    parameters ??= new DialogParameters();
+        ////    var isModal = parameters.TryGetValue<bool>(KnownDialogParameters.ShowNonModal, out var show) ? !show : true;
+        ////    var windowName = parameters.TryGetValue<string>(KnownDialogParameters.WindowName, out var wName) ? wName : null;
+        ////    var ownerWin = parameters.TryGetValue<Window>(KnownDialogParameters.ParentWindow, out var hWnd) ? hWnd : null;
+        ////
+        ////    dialogService.ShowDialog(name, parameters, callback);
+        ////}
 
         private static IDialogParameters EnsureShowNonModalParameter(IDialogParameters parameters)
         {

--- a/src/Prism.Avalonia/Dialogs/IDialogServiceCompatExtensions.cs
+++ b/src/Prism.Avalonia/Dialogs/IDialogServiceCompatExtensions.cs
@@ -50,17 +50,6 @@ namespace Prism.Dialogs
             dialogService.Show(name, parameters, callback);
         }
 
-        ////public static void ShowDialog(this IDialogService dialogService, Window owner, string name, IDialogParameters parameters, DialogCallback callback)
-        ////{
-        ////
-        ////    parameters ??= new DialogParameters();
-        ////    var isModal = parameters.TryGetValue<bool>(KnownDialogParameters.ShowNonModal, out var show) ? !show : true;
-        ////    var windowName = parameters.TryGetValue<string>(KnownDialogParameters.WindowName, out var wName) ? wName : null;
-        ////    var ownerWin = parameters.TryGetValue<Window>(KnownDialogParameters.ParentWindow, out var hWnd) ? hWnd : null;
-        ////
-        ////    dialogService.ShowDialog(name, parameters, callback);
-        ////}
-
         private static IDialogParameters EnsureShowNonModalParameter(IDialogParameters parameters)
         {
             parameters ??= new DialogParameters();

--- a/src/Prism.Avalonia/Dialogs/KnownDialogParameters.cs
+++ b/src/Prism.Avalonia/Dialogs/KnownDialogParameters.cs
@@ -8,4 +8,7 @@ public static class KnownDialogParameters
 
     /// <summary>Flag to show the Dialog Modally or Non-Modally.</summary>
     public const string ShowNonModal = "nonModal";
+
+    /// <summary>Host Window; when different from default.</summary>
+    public const string ParentWindow = "parentWindow";
 }


### PR DESCRIPTION
Update End-to-End Sample applications to use v9.0.271-pre

SampleDialogApp
* NEW: Sample using DialogParameters key, `KnownDialogParameters.WindowName`
* NEW: Setting custom parent window using DialogParameters key, `KnownDialogParameters.WindowName`
  * In Prism.Avalonia v8.1.97, this was a parameter in the `_dialogService.ShowDialog(...)`. Now you pass it as a parameter.