### PR TITLE
Prism v9.0.x-pre - v9.0.401-pre

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
 
   <!-- Prism -->
   <ItemGroup>
-    <PackageVersion Include="Prism.Core" Version="9.0.271-pre" />
+    <PackageVersion Include="Prism.Core" Version="9.0.401-pre" />
     <PackageVersion Include="Prism.Container.Abstractions" Version="9.0.84-pre" />
     <PackageVersion Include="Prism.Container.DryIoc" Version="9.0.84-pre" />
     <PackageVersion Include="Prism.Container.Unity" Version="9.0.84-pre" />


### PR DESCRIPTION
Upgraded Prism.Core to `v9.0.401-pre`

Previously missed