### PR TITLE
Update CoC grammar

### DIFF
--- a/.github/Code-of-Conduct.md
+++ b/.github/Code-of-Conduct.md
@@ -2,14 +2,15 @@
 
 ## Our Pledge
 
-We as member, contributors, and leaders pledge to make participation and knowledge readily available for others. We inspire everyone to learn from one another, to share ideas and help grow the community.
+We as members, contributors, and leaders pledge to make participation and knowledge readily available to others. We inspire everyone to learn from one another, to share ideas, and help grow the community.
 
 ## Our Standards
 
+* Focus on what is best to improve the project's codebase
+* Give constructive feedback
 * Be respectful towards one another
 * Feedback is welcome
 * Jokes are welcomed - _don't like it, rub dirt on it_
-* Focus on what is best to improve the project's codebase
-* Give constructive feedback
+* _Keep political views out of code_
 
 After all, we're all human.. _except for AI, that's just an algorithm_.


### PR DESCRIPTION
## Details

Fixed grammar in Code of Conduct. And, noted on, "_keep it to just coding_".