### PR TITLE
Upgrade Avalonia (11.1.3 to v11.2.8) and generic NuGet Packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,14 +8,14 @@
   </ItemGroup>
   <!-- Avalonia -->
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.LinuxFramebuffer" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.1.3" />
+    <PackageVersion Include="Avalonia" Version="11.2.8" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.2.8" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.8" />
+    <PackageVersion Include="Avalonia.LinuxFramebuffer" Version="11.2.8" />
+    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.2.8" />
+    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.2.8" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.8" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.8" />
   </ItemGroup>
   <!-- 3rd-Party -->
   <ItemGroup>


### PR DESCRIPTION
## Details

Update NuGet packages

* Upgrade Avalonia library packages from v11.1.3 to v11.2.8
* Moq
* Test packages
